### PR TITLE
Fix GUI dev command (by not trying to kill the process)

### DIFF
--- a/theseus_gui/README.md
+++ b/theseus_gui/README.md
@@ -9,6 +9,8 @@ pnpm install # Install dependencies
 pnpm dev # Start dev server
 ```
 
+> If after quitting the dev process, you find that the SvelteKit process is still running (or preventing you from restarting the dev command), run `pnpm kill:dev`
+
 ## Building
 
 ```bash

--- a/theseus_gui/package.json
+++ b/theseus_gui/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
-    "dev": "tauri dev; pnpm kill-port 3000",
+    "dev": "tauri dev",
     "dev:web": "svelte-kit dev",
+    "kill:web": "kill-port 3000",
     "tauri": "tauri",
     "build": "tauri build",
     "build:web": "svelte-kit build",


### PR DESCRIPTION
The `pnpm dev` command used to always try to kill the SvelteKit process, because of tauri-apps/tauri#2794, but that bug doesn't always happen, so the process killing has been moved to the `pnpm kill:web` command. See the readme:

> If after quitting the dev process, you find that the SvelteKit process is still running (or preventing you from restarting the dev command), run `pnpm kill:dev`