### PR TITLE
Jre detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,6 +3361,7 @@ dependencies = [
  "chrono",
  "daedalus",
  "dirs",
+ "dunce",
  "futures",
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,7 +2590,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -3362,6 +3362,7 @@ dependencies = [
  "daedalus",
  "dirs",
  "futures",
+ "lazy_static",
  "log",
  "once_cell",
  "pretty_assertions",
@@ -3378,6 +3379,7 @@ dependencies = [
  "tracing-error",
  "url",
  "uuid 1.3.0",
+ "winreg 0.11.0",
  "zip",
 ]
 
@@ -4178,6 +4180,16 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a1a57ff50e9b408431e8f97d5456f2807f8eb2a2cd79b06068fc87f8ecf189"
+dependencies = [
+ "cfg-if",
  "winapi",
 ]
 

--- a/theseus/Cargo.toml
+++ b/theseus/Cargo.toml
@@ -34,6 +34,7 @@ futures = "0.3"
 once_cell = "1.9.0"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
+lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies] 
 winreg = "0.11.0"

--- a/theseus/Cargo.toml
+++ b/theseus/Cargo.toml
@@ -38,6 +38,7 @@ lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies] 
 winreg = "0.11.0"
+dunce = "1.0.3"
 
 [dev-dependencies]
 argh = "0.1.6"

--- a/theseus/Cargo.toml
+++ b/theseus/Cargo.toml
@@ -28,11 +28,15 @@ thiserror = "1.0"
 tracing = "0.1"
 tracing-error = "0.2"
 
+
 async-tungstenite = { version = "0.17", features = ["tokio-runtime", "tokio-native-tls"] }
 futures = "0.3"
 once_cell = "1.9.0"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
+
+[target.'cfg(windows)'.dependencies] 
+winreg = "0.11.0"
 
 [dev-dependencies]
 argh = "0.1.6"

--- a/theseus/src/util/jre.rs
+++ b/theseus/src/util/jre.rs
@@ -11,7 +11,7 @@ use winreg::{
     RegKey,
 };
 
-// Uses dunce canonicaliztion to resolve symlinks without UNC prefixes
+// Uses dunce canonicalization to resolve symlinks without UNC prefixes
 #[cfg(target_os = "windows")]
 use dunce::canonicalize;
 #[cfg(not(target_os = "windows"))]
@@ -192,14 +192,14 @@ const JAVA_BIN: &'static str = "java.exe";
 #[allow(dead_code)]
 const JAVA_BIN: &'static str = "java";
 
+// For example filepath 'path', attempt to resolve it and get a Java version at this path
+// If no such path exists, or no such valid java at this path exists, returns None 
 #[tracing::instrument]
 pub fn check_java_at_filepath(path: PathBuf) -> Option<JavaVersion> {
     // Attempt to canonicalize the potential java filepath
     // If it fails, this path does not exist and None is returned (no Java here)
     let Ok(path) = canonicalize(path) else { return None };
     let Some(path_str) = path.to_str() else { return None };
-
-    println!("{}", path_str);
 
     // Checks for existence of Java at this filepath
     let java = path.join(JAVA_BIN);
@@ -238,16 +238,4 @@ pub enum JREError {
 
     #[error("Env error: {0}")]
     EnvError(#[from] env::VarError),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{get_all_jre, JREError};
-
-    #[test]
-    fn find_jre() -> Result<(), JREError> {
-        let jres = get_all_jre()?;
-        dbg!(&jres);
-        panic!("fail");
-    }
 }

--- a/theseus/src/util/jre.rs
+++ b/theseus/src/util/jre.rs
@@ -1,0 +1,105 @@
+use std::env;
+use std::path::Path;
+
+use thiserror::Error;
+use std::process::Command;
+
+
+#[derive(Debug)]
+pub struct JavaVersion {
+    path: String,
+    version: String,
+}
+impl JavaVersion {
+    pub fn new(path : String, version : String) -> Self {
+        JavaVersion { path, version }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_all_jre() -> Result<Vec<JavaVersion>,JREError> {
+    let jre_key = RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey(r"SOFTWARE\JavaSoft\Java Runtime Environment")
+        .expect("Failed to open registry key");
+
+
+    for subkey in jre_key.enum_keys().expect("Failed to enumerate subkeys") {
+        let subkey = subkey.expect("Failed to read subkey name");
+        let subkey = jre_key.open_subkey(subkey).expect("Failed to open subkey");
+
+        let version = subkey.get_value("JavaVersion")
+            .expect("Failed to get JavaVersion value")
+            .as_string()
+            .expect("JavaVersion is not a string");
+
+        let java_home = subkey.get_value("JavaHome")
+            .expect("Failed to get JavaHome value")
+            .as_string()
+            .expect("JavaHome is not a string");
+
+        println!("JRE version: {}", version);
+        println!("Java home: {}", java_home);
+    }
+}
+
+
+#[cfg(not(target_os = "windows"))]
+pub fn get_all_jre() -> Result<Vec<JavaVersion>,JREError>  {
+
+    // Iterate over values in PATH variable, where accessible JREs are referenced
+    let paths = env::var("PATH")?;
+    let paths = env::split_paths(&paths);
+
+    let mut jres = Vec::new();
+    for path in paths {
+        // Check if the path is valid and has a /java bin
+        let Some(path_str) = path.to_str() else { continue };
+        let java = path.join("java");
+        if !java.exists() { 
+            continue;
+        };
+
+        // Run 'java -version' using found java binary
+        let output = Command::new(&java).arg("-version").output()?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Extract version info from it
+        if stderr.contains("java version") {
+            let version_line = stderr.lines().next().ok_or_else(|| JREError::JREFormat)?;
+            let version = version_line.split("\"").nth(1).ok_or_else(|| JREError::JREFormat)?.to_string();
+            let path = path_str.to_string();
+            jres.push(JavaVersion {
+                path,
+                version
+            });
+        }
+    }
+
+    Ok(jres)
+}
+
+
+#[derive(thiserror::Error, Debug)]
+pub enum JREError {
+
+    #[error("Command : {0}")]
+    IOError(#[from] std::io::Error),
+
+    #[error("Env error: {0}")]
+    EnvError(#[from] env::VarError),
+
+    #[error("'java -version' returned improper result")]
+    JREFormat
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::get_all_jre;
+
+    #[test]
+    fn find_jre() {
+        let jres = get_all_jre().unwrap();
+        dbg!(&jres);
+        panic!("fail");
+    }
+}

--- a/theseus/src/util/jre.rs
+++ b/theseus/src/util/jre.rs
@@ -193,7 +193,7 @@ const JAVA_BIN: &'static str = "java.exe";
 const JAVA_BIN: &'static str = "java";
 
 // For example filepath 'path', attempt to resolve it and get a Java version at this path
-// If no such path exists, or no such valid java at this path exists, returns None 
+// If no such path exists, or no such valid java at this path exists, returns None
 #[tracing::instrument]
 pub fn check_java_at_filepath(path: PathBuf) -> Option<JavaVersion> {
     // Attempt to canonicalize the potential java filepath

--- a/theseus/src/util/jre.rs
+++ b/theseus/src/util/jre.rs
@@ -35,17 +35,17 @@ pub fn get_all_jre() -> Result<Vec<JavaVersion>, JREError> {
     jres.extend(get_all_jre_path()?);
 
     // Hard paths for locations for commonly installed .exes
-    let java_paths = [
-        r"C:/Program Files/Java/jre7",
-        r"C:/Program Files/Java/jre8",
-        r"C:/Program Files (x86)/Java/jre7",
-        r"C:/Program Files (x86)/Java/jre8",
-    ];
-    for path in java_paths {
-        if let Some(j) = check_java_at_filepath(PathBuf::from(path).join("bin"))
-        {
-            jres.insert(j);
-            break;
+    let java_paths = [r"C:/Program Files/Java", r"C:/Program Files (x86)/Java"];
+    for java_path in java_paths {
+        let Ok(java_subpaths) = std::fs::read_dir(java_path) else {continue };
+        for java_subpath in java_subpaths {
+            let path = java_subpath?.path();
+            if let Some(j) =
+                check_java_at_filepath(PathBuf::from(path).join("bin"))
+            {
+                jres.insert(j);
+                break;
+            }
         }
     }
 
@@ -121,7 +121,6 @@ pub fn get_all_jre() -> Result<Vec<JavaVersion>, JREError> {
         r"/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/MacOS/itms/java",
         r"/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home",
         r"/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands",
-        r"C:/Program Files (x86)/Java/jre8",
     ];
     for path in java_paths {
         if let Some(j) = check_java_at_filepath(PathBuf::from(path).join("bin"))

--- a/theseus/src/util/jre.rs
+++ b/theseus/src/util/jre.rs
@@ -125,8 +125,6 @@ pub fn get_all_jre() -> Result<Vec<JavaVersion>, JREError> {
             break;
         }
     }
-
-    jres.extend(get_all_jre_search()?);
     Ok(jres.into_iter().collect())
 }
 

--- a/theseus/src/util/jre.rs
+++ b/theseus/src/util/jre.rs
@@ -1,94 +1,220 @@
 use std::env;
-use std::path::Path;
-
-use thiserror::Error;
+use std::path::PathBuf;
+use regex::Regex;
+use lazy_static::lazy_static;
+use winreg::RegKey;
 use std::process::Command;
+use std::collections::HashSet;
 
-
-#[derive(Debug)]
+#[derive(Debug, PartialEq ,Eq, Hash)]
 pub struct JavaVersion {
     path: String,
     version: String,
 }
-impl JavaVersion {
-    pub fn new(path : String, version : String) -> Self {
-        JavaVersion { path, version }
+
+// Entrypoint function (Windows)
+// Returns a Vec of unique JavaVersions from the PATH, Windows Registry Keys and common Java locations
+#[cfg(target_os = "windows")]
+#[tracing::instrument]
+pub fn get_all_jre  () -> Result<Vec<JavaVersion>,JREError> {
+    use winreg::{RegKey, enums::{HKEY_LOCAL_MACHINE, KEY_READ, KEY_WOW64_32KEY, KEY_WOW64_64KEY}};
+
+    // Use HashSet to avoid duplicates
+    let mut jres = HashSet::new();
+
+    // Add JRES directly on PATH
+    jres.extend(get_all_jre_path()?);
+
+    // Hard paths for locations for commonly installed .exes
+    let java_paths = [
+        r"C:/Program Files/Java/jre7",
+        r"C:/Program Files/Java/jre8",
+        r"C:/Program Files (x86)/Java/jre7",
+        r"C:/Program Files (x86)/Java/jre8"
+    ];
+    for path in java_paths {
+        if let Some(j) = java_filepath_to_javaversion(PathBuf::from(path).join("bin")) {
+            jres.insert(j);
+            break;
+        }
     }
+
+    // Windows Registry Keys
+    let key_paths = [
+        r"SOFTWARE\JavaSoft\Java Runtime Environment", // Oracle
+        r"SOFTWARE\JavaSoft\Java Development Kit",
+        r"SOFTWARE\\JavaSoft\\JRE", // Oracle
+        r"SOFTWARE\\JavaSoft\\JDK",
+        r"SOFTWARE\\Eclipse Foundation\\JDK", // Eclipse
+        r"SOFTWARE\\Eclipse Adoptium\\JRE", // Eclipse
+        r"SOFTWARE\\Eclipse Foundation\\JDK", // Eclipse
+        r"SOFTWARE\\Microsoft\\JDK", // Microsoft
+    ];
+    for key in key_paths {
+        if let Ok(jre_key) =  RegKey::predef(HKEY_LOCAL_MACHINE)
+            .open_subkey_with_flags(key, KEY_READ | KEY_WOW64_32KEY) {
+            jres.extend(get_all_jre_winregkey(jre_key)?);
+        }
+        if let Ok(jre_key) =  RegKey::predef(HKEY_LOCAL_MACHINE)
+            .open_subkey_with_flags(key, KEY_READ | KEY_WOW64_64KEY) {
+            jres.extend(get_all_jre_winregkey(jre_key)?);
+        }
+    }
+
+    Ok(jres.into_iter().collect())
 }
 
 #[cfg(target_os = "windows")]
+#[tracing::instrument]
+pub fn get_all_jre_winregkey(jre_key : RegKey) -> Result<HashSet<JavaVersion>,JREError> {
+
+    let mut jres = HashSet::new();
+
+    for subkey in jre_key.enum_keys() {
+        let subkey = subkey?;
+        let subkey = jre_key.open_subkey(subkey)?;
+
+        let subkey_value_names = [
+            r"JavaHome",
+            r"InstallationPath",
+            r"\\hotspot\\MSI",
+        ];
+    
+        for subkey_value in subkey_value_names {
+            let path : Result<String, std::io::Error> = subkey.get_value(subkey_value);
+            let Ok(path) = path else {continue};
+            if let Some(j) = java_filepath_to_javaversion(PathBuf::from(path).join("bin")) {
+                jres.insert(j);
+                break;
+            }
+        }
+    }     
+    Ok(jres)
+}
+
+// Entrypoint function (Mac)
+// Returns a Vec of unique JavaVersions from the PATH, and common Java locations
+#[cfg(target_os = "macos")]
+#[tracing::instrument]
 pub fn get_all_jre() -> Result<Vec<JavaVersion>,JREError> {
-    let jre_key = RegKey::predef(HKEY_LOCAL_MACHINE)
-        .open_subkey(r"SOFTWARE\JavaSoft\Java Runtime Environment")
-        .expect("Failed to open registry key");
+    // Use HashSet to avoid duplicates
+    let mut jres = HashSet::new();
 
+    // Add JREs directly on PATH
+    jres.extend(get_all_jre_path()?);
 
-    for subkey in jre_key.enum_keys().expect("Failed to enumerate subkeys") {
-        let subkey = subkey.expect("Failed to read subkey name");
-        let subkey = jre_key.open_subkey(subkey).expect("Failed to open subkey");
-
-        let version = subkey.get_value("JavaVersion")
-            .expect("Failed to get JavaVersion value")
-            .as_string()
-            .expect("JavaVersion is not a string");
-
-        let java_home = subkey.get_value("JavaHome")
-            .expect("Failed to get JavaHome value")
-            .as_string()
-            .expect("JavaHome is not a string");
-
-        println!("JRE version: {}", version);
-        println!("Java home: {}", java_home);
+    // Hard paths for locations for commonly installed .exes
+    let java_paths = [
+        r"/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/MacOS/itms/java",
+        r"/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home",
+        r"/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands",
+        r"C:/Program Files (x86)/Java/jre8"
+    ];
+    for path in java_paths {
+        if let Some(j) = java_filepath_to_javaversion(PathBuf::from(path).join("bin")) {
+            jres.push(j);
+            break;
+        }
     }
+
+    jres.extend(get_all_jre_search()?);
+    Ok(jres.into_iter().collect())
+}
+
+// Entrypoint function (Linux)
+// Returns a Vec of unique JavaVersions from the PATH, and common Java locations
+#[cfg(target_os = "linux")]
+#[tracing::instrument]
+pub fn get_all_jre() -> Result<Vec<JavaVersion>,JREError> {
+    // Use HashSet to avoid duplicates
+    let mut jres = HashSet::new();
+
+    // Add JREs directly on PATH
+    jres.extend(get_all_jre_path()?);
+
+    // Hard paths for locations for commonly installed locations
+    let java_paths = [
+        r"/usr/java",
+        r"/usr/lib/jvm",
+        r"/usr/lib64/jvm",
+        r"/opt/jdk",
+        r"/opt/jdks"
+    ];
+    for path in java_paths {
+        if let Some(j) = java_filepath_to_javaversion(PathBuf::from(path).join("jre/bin")) {
+            jres.push(j);
+            break;
+        }
+        if let Some(j) = java_filepath_to_javaversion(PathBuf::from(path).join("bin")) {
+            jres.push(j);
+            break;
+        }
+    }
+    Ok(jres.into_iter().collect())
 }
 
 
-#[cfg(not(target_os = "windows"))]
-pub fn get_all_jre() -> Result<Vec<JavaVersion>,JREError>  {
-
+#[tracing::instrument]
+pub fn get_all_jre_path() -> Result<HashSet<JavaVersion>,JREError> {
     // Iterate over values in PATH variable, where accessible JREs are referenced
     let paths = env::var("PATH")?;
     let paths = env::split_paths(&paths);
 
-    let mut jres = Vec::new();
+    let mut jres = HashSet::new();
     for path in paths {
-        // Check if the path is valid and has a /java bin
-        let Some(path_str) = path.to_str() else { continue };
-        let java = path.join("java");
-        if !java.exists() { 
-            continue;
-        };
-
-        // Run 'java -version' using found java binary
-        let output = Command::new(&java).arg("-version").output()?;
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // Extract version info from it
-        if stderr.contains("java version") {
-            let version_line = stderr.lines().next().ok_or_else(|| JREError::JREFormat)?;
-            let version = version_line.split("\"").nth(1).ok_or_else(|| JREError::JREFormat)?.to_string();
-            let path = path_str.to_string();
-            jres.push(JavaVersion {
-                path,
-                version
-            });
+        if let Some(j) = java_filepath_to_javaversion(path) {
+            jres.insert(j);
         }
     }
-
     Ok(jres)
 }
 
+#[cfg(target_os = "windows")]
+#[allow(dead_code)]
+const JAVA_BIN : &'static str = "java.exe";
+
+#[cfg(not(target_os = "windows"))]
+#[allow(dead_code)]
+const JAVA_BIN : &'static str = "java";
+
+#[tracing::instrument]
+pub fn java_filepath_to_javaversion(path : PathBuf) -> Option<JavaVersion> {
+    let Some(path_str) = path.to_str() else { return None };
+    let java = path.join(JAVA_BIN);
+    if !java.exists() { 
+        return None;
+    };
+
+    // Run 'java -version' using found java binary
+    let output = Command::new(&java).arg("-version").output().ok()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Match: java version "1.8.0_361"
+    // Extracting version numbers
+    lazy_static! {
+        static ref JAVA_VERSION_CAPTURE : Regex = Regex::new(r#"^java version "([\d\._]+)""#).unwrap();
+    }
+
+    // Extract version info from it
+    if let Some(captures) = JAVA_VERSION_CAPTURE.captures(&stderr) {
+        if let Some(version) = captures.get(1) {
+            let path = path_str.to_string();
+            return Some(JavaVersion {
+                path,
+                version: version.as_str().to_string()
+            });        
+        }
+    }
+    None
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum JREError {
-
-    #[error("Command : {0}")]
+    #[error("Command error : {0}")]
     IOError(#[from] std::io::Error),
 
     #[error("Env error: {0}")]
     EnvError(#[from] env::VarError),
-
-    #[error("'java -version' returned improper result")]
-    JREFormat
 }
 
 

--- a/theseus/src/util/mod.rs
+++ b/theseus/src/util/mod.rs
@@ -1,6 +1,7 @@
 //! Theseus utility functions
 pub mod fetch;
 pub mod platform;
+pub mod jre;
 
 /// Wrap a builder which uses a mut reference into one which outputs an owned value
 macro_rules! wrap_ref_builder {

--- a/theseus/src/util/mod.rs
+++ b/theseus/src/util/mod.rs
@@ -1,7 +1,7 @@
 //! Theseus utility functions
 pub mod fetch;
-pub mod platform;
 pub mod jre;
+pub mod platform;
 
 /// Wrap a builder which uses a mut reference into one which outputs an owned value
 macro_rules! wrap_ref_builder {


### PR DESCRIPTION
Added JRE detection using function get_all_jre(), which returns a vec of _unique_ JavaVersions with all symlinks resolved. 

FIxes MOD-309