### PR TITLE
Windows compile opts

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(windows)']
+rustflags = ["-C", "link-args=/STACK:4194304"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
+# Windows has stack overflows when calling from Tauri, so we increase compiler size
 [target.'cfg(windows)']
 rustflags = ["-C", "link-args=/STACK:4194304"]


### PR DESCRIPTION
- added config.toml for windows specific compilation (increases stack size)