### PR TITLE
Update tauri content security policy

### DIFF
--- a/theseus_gui/src-tauri/tauri.conf.json
+++ b/theseus_gui/src-tauri/tauri.conf.json
@@ -60,7 +60,7 @@
       }
     },
     "security": {
-      "csp": "default-src 'self'; img-src 'self' asset: https://asset.localhost"
+      "csp": "default-src 'self'; connect-src https://modrinth.com https://*.modrinth.com; style-src https://rsms.me/inter/ 'unsafe-inline'; font-src https://rsms.me/inter/; img-src tauri: https: data: blob: 'unsafe-inline' asset: https://asset.localhost"
     },
     "updater": {
       "active": false


### PR DESCRIPTION
This fixes launcher pages being blocked by some system webview implementations.

Requires https://github.com/modrinth/knossos/pull/1106 and https://github.com/modrinth/omorphia/pull/41 to be merged first or images and videos on mod pages will not load.