### PR TITLE
Projects can be file-dropped into an instance.

### DIFF
--- a/theseus_gui/src/helpers/profile.js
+++ b/theseus_gui/src/helpers/profile.js
@@ -50,8 +50,8 @@ export async function add_project_from_version(path, version_id) {
 
 // Add a project to a profile from a path + project_type
 // Returns a path to the new project file
-export async function add_project_from_path(path, project_path, project_type) {
-  return await invoke('profile_add_project_from_path', { path, project_path, project_type })
+export async function add_project_from_path(path, projectPath, projectType) {
+  return await invoke('profile_add_project_from_path', { path, projectPath, projectType })
 }
 
 // Toggle disabling a project

--- a/theseus_gui/src/pages/instance/Mods.vue
+++ b/theseus_gui/src/pages/instance/Mods.vue
@@ -182,12 +182,15 @@ function updateSort(projects, sort) {
 }
 
 const unlisten = await listen('tauri://file-drop', async (e) => {
-  // Get the uploaded file from the payload and add it to profile
-  const projPath = e.payload[0]
-  await add_project_from_path(props.instance.path, projPath, 'inferred')
+  // Get the uploaded file(s) from the payload and add it to profile
+  // TODO: Don't do this iteratively when a batch add method is added
+  await e.payload.forEach(async (mod) => {
+    await add_project_from_path(props.instance.path, mod, 'inferred')
+  })
 
   // Get the profile. A get_proj_list_by_profile may be better here when one is made
   const profile = await get(props.instance.path)
+
   // Update the mods table
   formatProjects(Object.values(profile.projects))
 })


### PR DESCRIPTION
Fixes MOD-372

- Tauri listener added so a file can be dropped into the instance > mods page. The project will be added to the profile.
- onUnMounted is used to call the unlisten method. This is necessary to call `unlisten` once the handler is "out of scope"

Notes:
- It looks like we can setup other listeners like tauri://file-drop-hover to make the UI snappier. We could have an overlay show with "Drop file(s) here"
- The method to add the project to a profile takes awhile. This will feel better once the loading bars are added.