### PR TITLE
linux jre missing folders

### DIFF
--- a/theseus/src/util/jre.rs
+++ b/theseus/src/util/jre.rs
@@ -157,8 +157,16 @@ pub async fn get_all_jre() -> Result<Vec<JavaVersion>, JREError> {
         r"/opt/jdks",
     ];
     for path in java_paths {
-        jre_paths.insert(PathBuf::from(path).join("jre").join("bin"));
-        jre_paths.insert(PathBuf::from(path).join("bin"));
+        let path = PathBuf::from(path);
+        jre_paths.insert(PathBuf::from(&path).join("jre").join("bin"));
+        jre_paths.insert(PathBuf::from(&path).join("bin"));
+        if path.is_dir() {
+            for entry in std::fs::read_dir(&path)? {
+                let entry_path = entry?.path();
+                jre_paths.insert(entry_path.join("jre").join("bin"));
+                jre_paths.insert(entry_path.join("bin"));
+            }
+        }
     }
     // Get JRE versions from potential paths concurrently
     let j = check_java_at_filepaths(jre_paths)
@@ -194,7 +202,7 @@ pub async fn check_java_at_filepaths(
         .map(|p: PathBuf| {
             tokio::task::spawn(async move { check_java_at_filepath(&p).await })
         })
-        .buffer_unordered(64)
+        .buffer_unordered(500)
         .collect::<Vec<_>>()
         .await;
 

--- a/theseus/src/util/jre.rs
+++ b/theseus/src/util/jre.rs
@@ -168,6 +168,7 @@ pub async fn get_all_jre() -> Result<Vec<JavaVersion>, JREError> {
             }
         }
     }
+
     // Get JRE versions from potential paths concurrently
     let j = check_java_at_filepaths(jre_paths)
         .await?
@@ -202,7 +203,7 @@ pub async fn check_java_at_filepaths(
         .map(|p: PathBuf| {
             tokio::task::spawn(async move { check_java_at_filepath(&p).await })
         })
-        .buffer_unordered(500)
+        .buffer_unordered(64)
         .collect::<Vec<_>>()
         .await;
 


### PR DESCRIPTION
- JRE checker was not quite hitting all the folders listed for linux. It was searching for X/Y rather than X/{any folder}/Y