### PR TITLE
Adds Notifications system.

### DIFF
--- a/theseus_gui/src/components/ui/Notifications.vue
+++ b/theseus_gui/src/components/ui/Notifications.vue
@@ -1,0 +1,88 @@
+<script setup>
+import { useNotifications } from '@/store/notifications'
+
+const notificationStore = useNotifications()
+
+const stopTimer = (notif) => clearTimeout(notif.timer)
+</script>
+
+<template>
+  <div class="vue-notification-group">
+    <div
+      v-for="item in notificationStore.notifications"
+      :key="item.id"
+      class="vue-notification-wrapper"
+      @click="() => notificationStore.clearNotificationById(item.id)"
+      @mouseenter="stopTimer(item)"
+      @mouseleave="notificationStore.setNotificationTimer(item)"
+    >
+      <div class="vue-notification-template vue-notification" :class="{ [item.type]: true }">
+        <div class="notification-title" v-html="item.title"></div>
+        <div class="notification-content" v-html="item.text"></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.vue-notification {
+  background: var(--color-blue) !important;
+  border-left: 5px solid var(--color-blue) !important;
+  color: var(--color-contrast) !important;
+  box-sizing: border-box;
+  text-align: left;
+  font-size: 12px;
+  padding: 10px;
+  margin: 0 5px 5px;
+  &.success {
+    background: var(--color-green) !important;
+    border-left-color: var(--color-green) !important;
+  }
+  &.warn {
+    background: var(--color-orange) !important;
+    border-left-color: var(--color-orange) !important;
+  }
+  &.error {
+    background: var(--color-red) !important;
+    border-left-color: var(--color-red) !important;
+  }
+}
+.vue-notification-group {
+  position: fixed;
+  right: 25px;
+  bottom: 25px;
+  z-index: 99999999;
+  width: 300px;
+  .vue-notification-wrapper {
+    width: 100%;
+    overflow: hidden;
+    margin-bottom: 10px;
+    .vue-notification-template {
+      border-radius: var(--radius-md);
+      margin: 0;
+
+      .notification-title {
+        font-size: var(--font-size-lg);
+        margin-right: auto;
+        font-weight: 600;
+      }
+      .notification-content {
+        margin-right: auto;
+        font-size: var(--font-size-md);
+      }
+    }
+    &:last-child {
+      margin: 0;
+    }
+  }
+}
+.notifs-enter-active,
+.notifs-leave-active,
+.notifs-move {
+  transition: all 0.5s;
+}
+.notifs-enter-from,
+.notifs-leave-to {
+  opacity: 0;
+}
+</style>

--- a/theseus_gui/src/pages/Browse.vue
+++ b/theseus_gui/src/pages/Browse.vue
@@ -16,11 +16,11 @@ import {
   AnimatedLogo,
 } from 'omorphia'
 import Multiselect from 'vue-multiselect'
-import { useSearch } from '@/store/state'
-import { useBreadcrumbs } from '@/store/breadcrumbs'
+import { useSearch, useBreadcrumbs, useNotifications } from '@/store/state'
 import { get_categories, get_loaders, get_game_versions } from '@/helpers/tags'
 import { useRoute } from 'vue-router'
 
+const notificationStore = useNotifications()
 const searchStore = useSearch()
 const breadcrumbs = useBreadcrumbs()
 const route = useRoute()
@@ -40,9 +40,17 @@ const getSearchResults = async (shouldLoad = false) => {
   if (shouldLoad === true) {
     loading.value = true
   }
-  const response = await ofetch(`https://api.modrinth.com/v2/search${queryString}`)
-  loading.value = false
-  searchStore.setSearchResults(response)
+  try {
+    const response = await ofetch(`https://api.modrinth.com/v2/search${queryString}`)
+    loading.value = false
+    searchStore.setSearchResults(response)
+  } catch (err) {
+    notificationStore.addNotification({
+      title: 'Search Error',
+      text: 'A failure occurred during the search.',
+      type: 'error',
+    })
+  }
 }
 
 getSearchResults(true)

--- a/theseus_gui/src/pages/project/Index.vue
+++ b/theseus_gui/src/pages/project/Index.vue
@@ -218,7 +218,9 @@ import { ofetch } from 'ofetch'
 import { useRoute, useRouter } from 'vue-router'
 import { ref, shallowRef, watch } from 'vue'
 import InstallConfirmModal from '@/components/ui/InstallConfirmModal.vue'
-import { useBreadcrumbs } from '@/store/breadcrumbs'
+import { useBreadcrumbs, useNotifications } from '@/store/state'
+
+const notificationStore = useNotifications()
 
 const route = useRoute()
 const router = useRouter()
@@ -228,10 +230,42 @@ const confirmModal = ref(null)
 const loaders = ref(await get_loaders())
 const categories = ref(await get_categories())
 const [data, versions, members, dependencies] = await Promise.all([
-  ofetch(`https://api.modrinth.com/v2/project/${route.params.id}`).then(shallowRef),
-  ofetch(`https://api.modrinth.com/v2/project/${route.params.id}/version`).then(shallowRef),
-  ofetch(`https://api.modrinth.com/v2/project/${route.params.id}/members`).then(shallowRef),
-  ofetch(`https://api.modrinth.com/v2/project/${route.params.id}/dependencies`).then(shallowRef),
+  ofetch(`https://api.modrinth.com/v2/project/${route.params.id}`)
+    .then(shallowRef)
+    .catch(() =>
+      notificationStore.addNotification({
+        title: 'Error',
+        text: 'Something went wrong fetching the project data.',
+        type: 'error',
+      })
+    ),
+  ofetch(`https://api.modrinth.com/v2/project/${route.params.id}/version`)
+    .then(shallowRef)
+    .catch(() =>
+      notificationStore.addNotification({
+        title: 'Error',
+        text: 'Something went wrong getting the versions for the project.',
+        type: 'error',
+      })
+    ),
+  ofetch(`https://api.modrinth.com/v2/project/${route.params.id}/members`)
+    .then(shallowRef)
+    .catch(() =>
+      notificationStore.addNotification({
+        title: 'Error',
+        text: 'Something went wrong getting the members for th eproject.',
+        type: 'error',
+      })
+    ),
+  ofetch(`https://api.modrinth.com/v2/project/${route.params.id}/dependencies`)
+    .then(shallowRef)
+    .catch(() =>
+      notificationStore.addNotification({
+        title: 'Error',
+        text: 'Failure while fetching project dependencies.',
+        type: 'error',
+      })
+    ),
 ])
 
 breadcrumbs.setName('Project', data.value.title)

--- a/theseus_gui/src/store/notifications.js
+++ b/theseus_gui/src/store/notifications.js
@@ -1,0 +1,46 @@
+import { defineStore } from 'pinia'
+
+export const useNotifications = defineStore('notificationStore', {
+  state: () => ({
+    notifications: [], // should be an array of objects. { id, title, text, type, timer? }
+  }),
+  actions: {
+    setNotificationTimer(notif) {
+      if (!notif) return
+
+      if (notif.timer) clearTimeout(notif.timer)
+
+      notif.timer = setTimeout(() => {
+        this.clearNotificationByIndex(this.notifications.indexOf(notif))
+      }, 30000)
+    },
+    addNotification(newNotif) {
+      console.log('firing')
+      const existingNotif = this.notifications.find(
+        (n) =>
+          n.text === newNotif.text &&
+          n.title === newNotif.title &&
+          n.type === this.notifications.type
+      )
+
+      if (existingNotif) {
+        this.setNotificationTimer(existingNotif)
+        return
+      }
+
+      newNotif.id = new Date()
+      this.setNotificationTimer(newNotif)
+      this.notifications.push(newNotif)
+    },
+    clearNotificationByIndex(index) {
+      this.notifications.splice(index, 1)
+    },
+    clearNotificationById(id) {
+      const index = this.notifications.find((n) => n.id === id)
+      this.clearNotificationByIndex(index)
+    },
+    clearAllNotifications() {
+      this.notifications = []
+    },
+  },
+})

--- a/theseus_gui/src/store/state.js
+++ b/theseus_gui/src/store/state.js
@@ -1,5 +1,6 @@
 import { useSearch } from './search'
 import { useTheming } from './theme'
 import { useBreadcrumbs } from './breadcrumbs'
+import { useNotifications } from './notifications'
 
-export { useSearch, useTheming, useBreadcrumbs }
+export { useSearch, useTheming, useBreadcrumbs, useNotifications }


### PR DESCRIPTION
Fixes MOD-326

- Notification store added to track notifs
- Existing api calls on this branch are wrapped in try-catches. Errors will create new notifs.
- `warning_listener` brought in in App.vue

Todos:

- Iterate through possible warning events to create notifs
- Determine if we should store any info from the catch `err` in the notif's text
- Determine what functionality should generate success notifs