### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -25,18 +25,14 @@ jobs:
           path: ../target/**
           key: ${{ runner.os }}-theseus
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
           components: rustfmt, clippy
-      - uses: actions-rs/cargo@v1
-        name: Build program
-        with:
-          command: build
-          args: --bin theseus_cli
+      - name: Build program
+        run: cargo build --bin theseus_cli
       - name: Run Lint
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs-plus/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --bin theseus_cli

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -21,10 +21,9 @@ jobs:
         with:
           node-version: 16
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
           components: rustfmt, clippy
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-20.04'
@@ -53,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Lint
         if: matrix.platform == 'ubuntu-20.04'
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs-plus/clippy-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --bin theseus_cli


### PR DESCRIPTION
[`actions-rs` is unmaintained](https://github.com/actions-rs/toolchain/issues/216) and is still on Node 12. Actions using Node 12 will break on [May 18](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12), so this is more than just an unmaintained software issue - that being the CI will likely break on May 18.

This PR updates the actions to use [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) instead of the actions-rs version, and a revived version of the `clippy-check` action as well.