### PR TITLE
Adjust COPYING for Theseus

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -1,6 +1,6 @@
 # Copying
 
-The source code of the knossos repository is licensed under the GNU Affero General Public License, Version 3 only, which is provided in the file [LICENSE](./LICENSE). However, some files listed below are licensed under a different license.
+The source code of the theseus repository is licensed under the GNU General Public License, Version 3 only, which is provided in the file [LICENSE](./LICENSE). However, some files listed below are licensed under a different license.
 
 ## Modrinth logo
 


### PR DESCRIPTION
The COPYING.md file had a reference to knossos and its license, AGPL, carried over from that project. This PR corrects that to the current theseus license.