### PR TITLE
Fix correctly show in folder

### DIFF
--- a/theseus_gui/src-tauri/src/api/utils.rs
+++ b/theseus_gui/src-tauri/src/api/utils.rs
@@ -50,17 +50,7 @@ pub fn show_in_folder(path: String) -> Result<()> {
                 };
                 Command::new("xdg-open").arg(&new_path).spawn()?;
             } else {
-                Command::new("dbus-send")
-                    .args([
-                        "--session",
-                        "--dest=org.freedesktop.FileManager1",
-                        "--type=method_call",
-                        "/org/freedesktop/FileManager1",
-                        "org.freedesktop.FileManager1.ShowItems",
-                        format!("array:string:\"file://{path}\"").as_str(),
-                        "string:\"\"",
-                    ])
-                    .spawn()?;
+                Command::new("xdg-open").arg(&path).spawn()?;
             }
         }
 


### PR DESCRIPTION
Resolves #188
### Changes
We already use `xdg-open` to open paths with `,` so why not use it for normal paths too?

### Reason for changes
When attempting to open the profile's folder, I encountered some issues. In some cases, the file explorer would open but display an error message “Method not supported,” or it would indicate that the library needed for `dbus` was not found. 

### Tests
I tested my changes on both AppImage and `tauri dev`.

### Why it doesn't pass?
IDK! It works correctly on my computer, It looks like it doesn't have some envs. I didn't change anything that might interrupt that.