### PR TITLE
fixes

### DIFF
--- a/theseus/src/api/pack/import/atlauncher.rs
+++ b/theseus/src/api/pack/import/atlauncher.rs
@@ -229,7 +229,13 @@ async fn import_atlauncher_unmanaged(
     .await?;
 
     // Moves .minecraft folder over (ie: overrides such as resourcepacks, mods, etc)
-    copy_dotminecraft(profile_path.clone(), minecraft_folder).await?;
+    let state = State::get().await?;
+    copy_dotminecraft(
+        profile_path.clone(),
+        minecraft_folder,
+        &state.io_semaphore,
+    )
+    .await?;
 
     if let Some(profile_val) =
         crate::api::profile::get(&profile_path, None).await?

--- a/theseus/src/api/pack/import/curseforge.rs
+++ b/theseus/src/api/pack/import/curseforge.rs
@@ -83,7 +83,6 @@ pub async fn import_curseforge(
     let state = State::get().await?;
     // Recache Curseforge Icon if it exists
     let mut icon = None;
-    println!("{:?}", minecraft_instance);
 
     if let Some(icon_path) = minecraft_instance.profile_image_path.clone() {
         icon = recache_icon(icon_path).await?;
@@ -91,7 +90,6 @@ pub async fn import_curseforge(
         thumbnail_url: Some(thumbnail_url),
     }) = minecraft_instance.installed_modpack.clone()
     {
-        println!("Downloading icon from {}", thumbnail_url);
         let icon_bytes =
             fetch(&thumbnail_url, None, &state.fetch_semaphore).await?;
         let filename = thumbnail_url.rsplit('/').last();

--- a/theseus/src/api/pack/import/gdlauncher.rs
+++ b/theseus/src/api/pack/import/gdlauncher.rs
@@ -100,7 +100,13 @@ pub async fn import_gdlauncher(
     .await?;
 
     // Copy in contained folders as overrides
-    copy_dotminecraft(profile_path.clone(), gdlauncher_instance_folder).await?;
+    let state = State::get().await?;
+    copy_dotminecraft(
+        profile_path.clone(),
+        gdlauncher_instance_folder,
+        &state.io_semaphore,
+    )
+    .await?;
 
     if let Some(profile_val) =
         crate::api::profile::get(&profile_path, None).await?

--- a/theseus/src/api/pack/import/mmc.rs
+++ b/theseus/src/api/pack/import/mmc.rs
@@ -280,7 +280,13 @@ async fn import_mmc_unmanaged(
     .await?;
 
     // Moves .minecraft folder over (ie: overrides such as resourcepacks, mods, etc)
-    copy_dotminecraft(profile_path.clone(), minecraft_folder).await?;
+    let state = State::get().await?;
+    copy_dotminecraft(
+        profile_path.clone(),
+        minecraft_folder,
+        &state.io_semaphore,
+    )
+    .await?;
 
     if let Some(profile_val) =
         crate::api::profile::get(&profile_path, None).await?

--- a/theseus/src/api/pack/install_mrpack.rs
+++ b/theseus/src/api/pack/install_mrpack.rs
@@ -9,7 +9,7 @@ use crate::prelude::ProfilePathId;
 use crate::state::{ProfileInstallStage, Profiles, SideType};
 use crate::util::fetch::{fetch_mirrors, write};
 use crate::util::io;
-use crate::State;
+use crate::{profile, State};
 use async_zip::tokio::read::seek::ZipFileReader;
 
 use std::io::Cursor;
@@ -82,6 +82,7 @@ pub async fn install_zipped_mrpack_files(
     let version_id = create_pack.description.version_id;
     let existing_loading_bar = create_pack.description.existing_loading_bar;
     let profile_path = create_pack.description.profile_path;
+    let icon_exists = icon.is_some();
 
     let reader: Cursor<&bytes::Bytes> = Cursor::new(&file);
 
@@ -186,7 +187,7 @@ pub async fn install_zipped_mrpack_files(
                                 let path = profile_path
                                     .get_full_path()
                                     .await?
-                                    .join(project.path);
+                                    .join(&project.path);
                                 write(&path, &file, &state.io_semaphore)
                                     .await?;
                             }
@@ -259,6 +260,14 @@ pub async fn install_zipped_mrpack_files(
                 )
                 .await?;
             }
+        }
+
+        // If the icon doesn't exist, we expect icon.png to be a potential icon.
+        // If it doesn't exist, and an override to icon.png exists, cache and use that
+        let potential_icon =
+            profile_path.get_full_path().await?.join("icon.png");
+        if !icon_exists && potential_icon.exists() {
+            profile::edit_icon(&profile_path, Some(&potential_icon)).await?;
         }
 
         if let Some(profile_val) =

--- a/theseus/src/api/profile/create.rs
+++ b/theseus/src/api/profile/create.rs
@@ -104,7 +104,7 @@ pub async fn profile_create(
 
         emit_profile(
             uuid,
-            profile.get_profile_full_path().await?,
+            &profile.profile_id(),
             &profile.metadata.name,
             ProfilePayloadType::Created,
         )

--- a/theseus/src/api/profile/mod.rs
+++ b/theseus/src/api/profile/mod.rs
@@ -162,7 +162,7 @@ pub async fn edit_icon(
 
                 emit_profile(
                     profile.uuid,
-                    &path,
+                    path,
                     &profile.metadata.name,
                     ProfilePayloadType::Edited,
                 )
@@ -330,7 +330,7 @@ pub async fn update_all_projects(
 
         emit_profile(
             profile.uuid,
-            &profile_path,
+            profile_path,
             &profile.metadata.name,
             ProfilePayloadType::Edited,
         )
@@ -392,7 +392,7 @@ pub async fn update_project(
                 if !skip_send_event.unwrap_or(false) {
                     emit_profile(
                         profile.uuid,
-                        &profile_path,
+                        profile_path,
                         &profile.metadata.name,
                         ProfilePayloadType::Edited,
                     )
@@ -428,7 +428,7 @@ pub async fn add_project_from_version(
 
         emit_profile(
             profile.uuid,
-            &profile_path,
+            profile_path,
             &profile.metadata.name,
             ProfilePayloadType::Edited,
         )
@@ -468,7 +468,7 @@ pub async fn add_project_from_path(
 
         emit_profile(
             profile.uuid,
-            &profile_path,
+            profile_path,
             &profile.metadata.name,
             ProfilePayloadType::Edited,
         )
@@ -497,7 +497,7 @@ pub async fn toggle_disable_project(
 
         emit_profile(
             profile.uuid,
-            &profile_path,
+            profile_path,
             &profile.metadata.name,
             ProfilePayloadType::Edited,
         )
@@ -506,8 +506,10 @@ pub async fn toggle_disable_project(
 
         Ok(res)
     } else {
-        Err(crate::ErrorKind::UnmanagedProfileError(profile_path.to_string())
-            .as_error())
+        Err(
+            crate::ErrorKind::UnmanagedProfileError(profile_path.to_string())
+                .as_error(),
+        )
     }
 }
 
@@ -532,8 +534,10 @@ pub async fn remove_project(
 
         Ok(())
     } else {
-        Err(crate::ErrorKind::UnmanagedProfileError(profile_path.to_string())
-            .as_error())
+        Err(
+            crate::ErrorKind::UnmanagedProfileError(profile_path.to_string())
+                .as_error(),
+        )
     }
 }
 
@@ -1033,5 +1037,5 @@ pub async fn build_folder(
 }
 
 pub fn sanitize_profile_name(input: &str) -> String {
-    input.replace(['/', '\\'], "_")
+    input.replace(['/', '\\', ':'], "_")
 }

--- a/theseus/src/api/profile/update.rs
+++ b/theseus/src/api/profile/update.rs
@@ -57,7 +57,7 @@ pub async fn update_managed_modrinth(
 
     emit_profile(
         profile.uuid,
-        profile.path,
+        profile_path,
         &profile.metadata.name,
         ProfilePayloadType::Edited,
     )
@@ -133,7 +133,7 @@ pub async fn repair_managed_modrinth(
 
     emit_profile(
         profile.uuid,
-        profile.path,
+        profile_path,
         &profile.metadata.name,
         ProfilePayloadType::Edited,
     )

--- a/theseus/src/event/emit.rs
+++ b/theseus/src/event/emit.rs
@@ -4,7 +4,8 @@ use crate::{
         CommandPayload, EventError, LoadingBar, LoadingBarType,
         ProcessPayloadType, ProfilePayloadType,
     },
-    state::{ProcessType, SafeProcesses}, prelude::ProfilePathId,
+    prelude::ProfilePathId,
+    state::{ProcessType, SafeProcesses},
 };
 use futures::prelude::*;
 
@@ -281,7 +282,7 @@ pub async fn emit_process(
 #[allow(unused_variables)]
 pub async fn emit_profile(
     uuid: Uuid,
-    profile_path_id : &ProfilePathId,
+    profile_path_id: &ProfilePathId,
     name: &str,
     event: ProfilePayloadType,
 ) -> crate::Result<()> {

--- a/theseus/src/event/emit.rs
+++ b/theseus/src/event/emit.rs
@@ -4,10 +4,9 @@ use crate::{
         CommandPayload, EventError, LoadingBar, LoadingBarType,
         ProcessPayloadType, ProfilePayloadType,
     },
-    state::{ProcessType, SafeProcesses},
+    state::{ProcessType, SafeProcesses}, prelude::ProfilePathId,
 };
 use futures::prelude::*;
-use std::path::PathBuf;
 
 #[cfg(feature = "tauri")]
 use crate::event::{
@@ -282,12 +281,13 @@ pub async fn emit_process(
 #[allow(unused_variables)]
 pub async fn emit_profile(
     uuid: Uuid,
-    path: PathBuf,
+    profile_path_id : &ProfilePathId,
     name: &str,
     event: ProfilePayloadType,
 ) -> crate::Result<()> {
     #[cfg(feature = "tauri")]
     {
+        let path = profile_path_id.get_full_path().await?;
         let event_state = crate::EventState::get().await?;
         event_state
             .app
@@ -295,6 +295,7 @@ pub async fn emit_profile(
                 "profile",
                 ProfilePayload {
                     uuid,
+                    profile_path_id: profile_path_id.clone(),
                     path,
                     name: name.to_string(),
                     event,

--- a/theseus/src/event/mod.rs
+++ b/theseus/src/event/mod.rs
@@ -5,6 +5,7 @@ use tokio::sync::OnceCell;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
+use crate::prelude::ProfilePathId;
 use crate::state::SafeProcesses;
 
 pub mod emit;
@@ -235,6 +236,7 @@ pub enum ProcessPayloadType {
 #[derive(Serialize, Clone)]
 pub struct ProfilePayload {
     pub uuid: Uuid,
+    pub profile_path_id: ProfilePathId,
     pub path: PathBuf,
     pub name: String,
     pub event: ProfilePayloadType,

--- a/theseus/src/state/profiles.rs
+++ b/theseus/src/state/profiles.rs
@@ -303,7 +303,10 @@ impl Profile {
                 let profile = crate::api::profile::get(&path, None).await?;
 
                 if let Some(profile) = profile {
-                    emit_warning(&format!("Profile {} has crashed! Visit the logs page to see a crash report.", profile.metadata.name)).await?;
+                    // Hide warning if profile is not yet installed
+                    if profile.install_stage == ProfileInstallStage::Installed {
+                        emit_warning(&format!("Profile {} has crashed! Visit the logs page to see a crash report.", profile.metadata.name)).await?;
+                    }
                 }
 
                 Ok::<(), crate::Error>(())
@@ -354,7 +357,7 @@ impl Profile {
                     }
                     emit_profile(
                         profile.uuid,
-                        profile.get_profile_full_path().await?,
+                        &profile_path_id,
                         &profile.metadata.name,
                         ProfilePayloadType::Synced,
                     )
@@ -856,7 +859,7 @@ impl Profiles {
     pub async fn insert(&mut self, profile: Profile) -> crate::Result<&Self> {
         emit_profile(
             profile.uuid,
-            profile.get_profile_full_path().await?,
+            &profile.profile_id(),
             &profile.metadata.name,
             ProfilePayloadType::Added,
         )
@@ -943,7 +946,7 @@ impl Profiles {
                         // if path exists in the state but no longer in the filesystem, remove it from the state list
                         emit_profile(
                             profile.uuid,
-                            profile.get_profile_full_path().await?,
+                            &profile_path_id,
                             &profile.metadata.name,
                             ProfilePayloadType::Removed,
                         )

--- a/theseus/src/util/io.rs
+++ b/theseus/src/util/io.rs
@@ -1,6 +1,8 @@
 // IO error
 // A wrapper around the tokio IO functions that adds the path to the error message, instead of the uninformative std::io::Error.
 
+use std::path::Path;
+
 #[derive(Debug, thiserror::Error)]
 pub enum IOError {
     #[error("{source}, path: {path}")]
@@ -140,7 +142,7 @@ pub async fn copy(
     from: impl AsRef<std::path::Path>,
     to: impl AsRef<std::path::Path>,
 ) -> Result<u64, IOError> {
-    let from = from.as_ref();
+    let from: &Path = from.as_ref();
     let to = to.as_ref();
     tokio::fs::copy(from, to)
         .await

--- a/theseus_gui/src-tauri/src/api/utils.rs
+++ b/theseus_gui/src-tauri/src/api/utils.rs
@@ -1,3 +1,4 @@
+use serde::{Serialize, Deserialize};
 use theseus::{handler, prelude::CommandPayload, State};
 
 use crate::api::Result;
@@ -6,6 +7,7 @@ use std::{env, process::Command};
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     tauri::plugin::Builder::new("utils")
         .invoke_handler(tauri::generate_handler![
+            get_os,
             should_disable_mouseover,
             show_in_folder,
             progress_bars_list,
@@ -14,6 +16,24 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             await_sync,
         ])
         .build()
+}
+
+/// Gets OS
+#[tauri::command]
+pub fn get_os() -> OS {
+    #[cfg(target_os = "windows")]
+    let os = OS::Windows;
+    #[cfg(target_os = "linux")]
+    let os = OS::Linux;
+    #[cfg(target_os = "macos")]
+    let os = OS::MacOS;
+    os
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OS {
+    Windows,
+    Linux,
+    MacOS,
 }
 
 // Lists active progress bars

--- a/theseus_gui/src-tauri/src/api/utils.rs
+++ b/theseus_gui/src-tauri/src/api/utils.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use theseus::{handler, prelude::CommandPayload, State};
 
 use crate::api::Result;

--- a/theseus_gui/src/App.vue
+++ b/theseus_gui/src/App.vue
@@ -40,7 +40,7 @@ import OnboardingScreen from '@/components/ui/tutorial/OnboardingScreen.vue'
 const themeStore = useTheming()
 const urlModal = ref(null)
 const isLoading = ref(true)
-const videoPlaying = ref(true)
+const videoPlaying = ref(false)
 const showOnboarding = ref(false)
 
 const onboardingVideo = ref()
@@ -50,6 +50,7 @@ defineExpose({
     isLoading.value = false
     const { theme, opt_out_analytics, collapsed_navigation, advanced_rendering, onboarded_new } =
       await get()
+    videoPlaying.value = !onboarded_new
     const dev = await isDev()
     const version = await getVersion()
     showOnboarding.value = !onboarded_new

--- a/theseus_gui/src/App.vue
+++ b/theseus_gui/src/App.vue
@@ -24,7 +24,7 @@ import { command_listener, warning_listener } from '@/helpers/events.js'
 import { MinimizeIcon, MaximizeIcon } from '@/assets/icons'
 import { type } from '@tauri-apps/api/os'
 import { appWindow } from '@tauri-apps/api/window'
-import { isDev } from '@/helpers/utils.js'
+import { isDev, getOS } from '@/helpers/utils.js'
 import mixpanel from 'mixpanel-browser'
 import { saveWindowState, StateFlags } from 'tauri-plugin-window-state-api'
 import { getVersion } from '@tauri-apps/api/app'
@@ -50,7 +50,9 @@ defineExpose({
     isLoading.value = false
     const { theme, opt_out_analytics, collapsed_navigation, advanced_rendering, onboarded_new } =
       await get()
-    videoPlaying.value = !onboarded_new
+    const os = await getOS()
+    // video should play if the user is not on linux, and has not onboarded
+    videoPlaying.value = !onboarded_new && os !== 'Linux'
     const dev = await isDev()
     const version = await getVersion()
     showOnboarding.value = !onboarded_new

--- a/theseus_gui/src/App.vue
+++ b/theseus_gui/src/App.vue
@@ -25,7 +25,12 @@ import { MinimizeIcon, MaximizeIcon } from '@/assets/icons'
 import { type } from '@tauri-apps/api/os'
 import { appWindow } from '@tauri-apps/api/window'
 import { isDev, getOS, isOffline } from '@/helpers/utils.js'
-import mixpanel from 'mixpanel-browser'
+import {
+  mixpanel_track,
+  mixpanel_init,
+  mixpanel_opt_out_tracking,
+  mixpanel_is_loaded,
+} from '@/helpers/mixpanel'
 import { saveWindowState, StateFlags } from 'tauri-plugin-window-state-api'
 import { getVersion } from '@tauri-apps/api/app'
 import { window as TauriWindow } from '@tauri-apps/api'

--- a/theseus_gui/src/components/ui/ExportModal.vue
+++ b/theseus_gui/src/components/ui/ExportModal.vue
@@ -188,7 +188,6 @@ const exportPack = async () => {
 }
 
 .select-checkbox {
-
   button.checkbox {
     border: none;
   }

--- a/theseus_gui/src/components/ui/ExportModal.vue
+++ b/theseus_gui/src/components/ui/ExportModal.vue
@@ -188,6 +188,7 @@ const exportPack = async () => {
 }
 
 .select-checkbox {
+
   button.checkbox {
     border: none;
   }

--- a/theseus_gui/src/components/ui/InstanceCreationModal.vue
+++ b/theseus_gui/src/components/ui/InstanceCreationModal.vue
@@ -219,7 +219,11 @@ import mixpanel from 'mixpanel-browser'
 import { useTheming } from '@/store/state.js'
 import { listen } from '@tauri-apps/api/event'
 import { install_from_file } from '@/helpers/pack.js'
-import { get_default_launcher_path, get_importable_instances, import_instance } from '@/helpers/import.js'
+import {
+  get_default_launcher_path,
+  get_importable_instances,
+  import_instance,
+} from '@/helpers/import.js'
 
 const themeStore = useTheming()
 
@@ -251,8 +255,7 @@ defineExpose({
     isShowing.value = true
     modal.value.show()
 
-
-   unlistener.value = await listen('tauri://file-drop', async (event) => {
+    unlistener.value = await listen('tauri://file-drop', async (event) => {
       // Only if modal is showing
       if (!isShowing.value) return
       if (creationType.value !== 'from file') return
@@ -265,14 +268,13 @@ defineExpose({
       }
     })
 
-
     mixpanel.track('InstanceCreateStart', { source: 'CreationModal' })
   },
 })
 
-const unlistener = ref(null);
+const unlistener = ref(null)
 const hide = () => {
-  console.log("hiding nicely")
+  console.log('hiding nicely')
   isShowing.value = false
   modal.value.hide()
   if (unlistener.value) {
@@ -286,9 +288,6 @@ onUnmounted(() => {
     unlistener.value = null
   }
 })
-
-
-
 
 const [fabric_versions, forge_versions, quilt_versions, all_game_versions, loaders] =
   await Promise.all([
@@ -411,7 +410,6 @@ const openFile = async () => {
   })
 }
 
-
 const profiles = ref(
   new Map([
     ['MultiMC', []],
@@ -440,10 +438,8 @@ const promises = profileOptions.value.map(async (option) => {
 
   // Try catch to allow failure and simply ignore default path attempt
   try {
-    const instances = await get_importable_instances(
-      option.name,
-      path)
-  
+    const instances = await get_importable_instances(option.name, path)
+
     if (!instances) return
     profileOptions.value.find((profile) => profile.name === option.name).path = path
     profiles.value.set(
@@ -455,7 +451,6 @@ const promises = profileOptions.value.map(async (option) => {
   }
 })
 await Promise.all(promises)
-
 
 const selectLauncherPath = async () => {
   selectedProfileType.value.path = await open({ multiple: false, directory: true })
@@ -472,9 +467,10 @@ const reload = async () => {
   ).catch(handleError)
   if (instances) {
     profiles.value.set(
-    selectedProfileType.value.name,
-    instances.map((name) => ({ name, selected: false }))
-  ) } else {
+      selectedProfileType.value.name,
+      instances.map((name) => ({ name, selected: false }))
+    )
+  } else {
     profiles.value.set(selectedProfileType.value.name, [])
   }
 

--- a/theseus_gui/src/components/ui/InstanceCreationModal.vue
+++ b/theseus_gui/src/components/ui/InstanceCreationModal.vue
@@ -73,7 +73,7 @@
           <CodeIcon />
           {{ showAdvanced ? 'Hide advanced' : 'Show advanced' }}
         </Button>
-        <Button @click="$refs.modal.hide()">
+        <Button @click="hide()">
           <XIcon />
           Cancel
         </Button>
@@ -202,7 +202,7 @@ import {
   FolderSearchIcon,
   UpdatedIcon,
 } from 'omorphia'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, onUnmounted, ref, shallowRef } from 'vue'
 import { get_loaders } from '@/helpers/tags'
 import { create } from '@/helpers/profile'
 import { open } from '@tauri-apps/api/dialog'
@@ -219,7 +219,7 @@ import mixpanel from 'mixpanel-browser'
 import { useTheming } from '@/store/state.js'
 import { listen } from '@tauri-apps/api/event'
 import { install_from_file } from '@/helpers/pack.js'
-import { get_importable_instances, import_instance } from '@/helpers/import.js'
+import { get_default_launcher_path, get_importable_instances, import_instance } from '@/helpers/import.js'
 
 const themeStore = useTheming()
 
@@ -234,9 +234,10 @@ const showAdvanced = ref(false)
 const creating = ref(false)
 const showSnapshots = ref(false)
 const creationType = ref('from file')
+const isShowing = ref(false)
 
 defineExpose({
-  show: () => {
+  show: async () => {
     game_version.value = ''
     specified_loader_version.value = ''
     profile_name.value = ''
@@ -247,11 +248,47 @@ defineExpose({
     loader_version.value = 'stable'
     icon.value = null
     display_icon.value = null
+    isShowing.value = true
     modal.value.show()
+
+
+   unlistener.value = await listen('tauri://file-drop', async (event) => {
+      // Only if modal is showing
+      if (!isShowing.value) return
+      if (creationType.value !== 'from file') return
+      hide()
+      if (event.payload && event.payload.length > 0 && event.payload[0].endsWith('.mrpack')) {
+        await install_from_file(event.payload[0]).catch(handleError)
+        mixpanel.track('InstanceCreate', {
+          source: 'CreationModalFileDrop',
+        })
+      }
+    })
+
 
     mixpanel.track('InstanceCreateStart', { source: 'CreationModal' })
   },
 })
+
+const unlistener = ref(null);
+const hide = () => {
+  console.log("hiding nicely")
+  isShowing.value = false
+  modal.value.hide()
+  if (unlistener.value) {
+    unlistener.value()
+    unlistener.value = null
+  }
+}
+onUnmounted(() => {
+  if (unlistener.value) {
+    unlistener.value()
+    unlistener.value = null
+  }
+})
+
+
+
 
 const [fabric_versions, forge_versions, quilt_versions, all_game_versions, loaders] =
   await Promise.all([
@@ -303,7 +340,7 @@ const create_instance = async () => {
     loader_version.value === 'other' ? specified_loader_version.value : loader_version.value
   const loaderVersion = loader.value === 'vanilla' ? null : loader_version_value ?? 'stable'
 
-  modal.value.hide()
+  hide()
   creating.value = false
 
   await create(
@@ -366,8 +403,7 @@ const toggle_advanced = () => {
 const openFile = async () => {
   const newProject = await open({ multiple: false })
   if (!newProject) return
-
-  modal.value.hide()
+  hide()
   await install_from_file(newProject).catch(handleError)
 
   mixpanel.track('InstanceCreate', {
@@ -375,15 +411,6 @@ const openFile = async () => {
   })
 }
 
-listen('tauri://file-drop', async (event) => {
-  modal.value.hide()
-  if (event.payload && event.payload.length > 0 && event.payload[0].endsWith('.mrpack')) {
-    await install_from_file(event.payload[0]).catch(handleError)
-    mixpanel.track('InstanceCreate', {
-      source: 'CreationModalFileDrop',
-    })
-  }
-})
 
 const profiles = ref(
   new Map([
@@ -406,6 +433,30 @@ const profileOptions = ref([
   { name: 'PrismLauncher', path: '' },
 ])
 
+// Attempt to get import profiles on default paths
+const promises = profileOptions.value.map(async (option) => {
+  const path = await get_default_launcher_path(option.name).catch(handleError)
+  if (!path || path === '') return
+
+  // Try catch to allow failure and simply ignore default path attempt
+  try {
+    const instances = await get_importable_instances(
+      option.name,
+      path)
+  
+    if (!instances) return
+    profileOptions.value.find((profile) => profile.name === option.name).path = path
+    profiles.value.set(
+      option.name,
+      instances.map((name) => ({ name, selected: false }))
+    )
+  } catch (error) {
+    // Allow failure silently
+  }
+})
+await Promise.all(promises)
+
+
 const selectLauncherPath = async () => {
   selectedProfileType.value.path = await open({ multiple: false, directory: true })
 
@@ -419,10 +470,15 @@ const reload = async () => {
     selectedProfileType.value.name,
     selectedProfileType.value.path
   ).catch(handleError)
-  profiles.value.set(
+  if (instances) {
+    profiles.value.set(
     selectedProfileType.value.name,
     instances.map((name) => ({ name, selected: false }))
-  )
+  ) } else {
+    profiles.value.set(selectedProfileType.value.name, [])
+  }
+
+  console.log(instances)
 }
 
 const setPath = () => {

--- a/theseus_gui/src/components/ui/InstanceCreationModal.vue
+++ b/theseus_gui/src/components/ui/InstanceCreationModal.vue
@@ -274,7 +274,6 @@ defineExpose({
 
 const unlistener = ref(null)
 const hide = () => {
-  console.log('hiding nicely')
   isShowing.value = false
   modal.value.hide()
   if (unlistener.value) {
@@ -473,8 +472,6 @@ const reload = async () => {
   } else {
     profiles.value.set(selectedProfileType.value.name, [])
   }
-
-  console.log(instances)
 }
 
 const setPath = () => {

--- a/theseus_gui/src/components/ui/InstanceCreationModal.vue
+++ b/theseus_gui/src/components/ui/InstanceCreationModal.vue
@@ -12,7 +12,7 @@
             <UploadIcon />
             Select icon
           </Button>
-          <Button @click="reset_icon">
+          <Button :disabled="!display_icon" @click="reset_icon">
             <XIcon />
             Remove icon
           </Button>

--- a/theseus_gui/src/components/ui/JavaDetectionModal.vue
+++ b/theseus_gui/src/components/ui/JavaDetectionModal.vue
@@ -99,6 +99,8 @@ function setJavaInstall(javaInstall) {
       align-items: center;
       justify-content: center;
     }
+
+    padding: 0.5rem;
   }
 }
 

--- a/theseus_gui/src/components/ui/ModInstallModal.vue
+++ b/theseus_gui/src/components/ui/ModInstallModal.vue
@@ -264,7 +264,7 @@ const check_valid = computed(() => {
                 <UploadIcon />
                 <span class="no-wrap"> Select icon </span>
               </Button>
-              <Button @click="reset_icon()">
+              <Button  :disabled="!display_icon" @click="reset_icon()">
                 <XIcon />
                 <span class="no-wrap"> Remove icon </span>
               </Button>

--- a/theseus_gui/src/components/ui/ModInstallModal.vue
+++ b/theseus_gui/src/components/ui/ModInstallModal.vue
@@ -65,7 +65,6 @@ const profiles = ref([])
 
 async function install(instance) {
   instance.installing = true
-  console.log(versions.value)
   const version = versions.value.find((v) => {
     return (
       v.game_versions.includes(instance.metadata.game_version) &&

--- a/theseus_gui/src/components/ui/ModInstallModal.vue
+++ b/theseus_gui/src/components/ui/ModInstallModal.vue
@@ -264,7 +264,7 @@ const check_valid = computed(() => {
                 <UploadIcon />
                 <span class="no-wrap"> Select icon </span>
               </Button>
-              <Button  :disabled="!display_icon" @click="reset_icon()">
+              <Button :disabled="!display_icon" @click="reset_icon()">
                 <XIcon />
                 <span class="no-wrap"> Remove icon </span>
               </Button>

--- a/theseus_gui/src/components/ui/tutorial/ImportingCard.vue
+++ b/theseus_gui/src/components/ui/tutorial/ImportingCard.vue
@@ -10,7 +10,11 @@ import {
   UpdatedIcon,
 } from 'omorphia'
 import { ref } from 'vue'
-import { get_default_launcher_path, get_importable_instances, import_instance } from '@/helpers/import.js'
+import {
+  get_default_launcher_path,
+  get_importable_instances,
+  import_instance,
+} from '@/helpers/import.js'
 import { open } from '@tauri-apps/api/dialog'
 import { handleError } from '@/store/state.js'
 
@@ -46,7 +50,6 @@ const profileOptions = ref([
   { name: 'PrismLauncher', path: '' },
 ])
 
-
 // Attempt to get import profiles on default paths
 const promises = profileOptions.value.map(async (option) => {
   const path = await get_default_launcher_path(option.name).catch(handleError)
@@ -54,10 +57,8 @@ const promises = profileOptions.value.map(async (option) => {
 
   // Try catch to allow failure and simply ignore default path attempt
   try {
-    const instances = await get_importable_instances(
-      option.name,
-      path)
-  
+    const instances = await get_importable_instances(option.name, path)
+
     if (!instances) return
     profileOptions.value.find((profile) => profile.name === option.name).path = path
     profiles.value.set(

--- a/theseus_gui/src/components/ui/tutorial/ImportingCard.vue
+++ b/theseus_gui/src/components/ui/tutorial/ImportingCard.vue
@@ -10,7 +10,7 @@ import {
   UpdatedIcon,
 } from 'omorphia'
 import { ref } from 'vue'
-import { get_importable_instances, import_instance } from '@/helpers/import.js'
+import { get_default_launcher_path, get_importable_instances, import_instance } from '@/helpers/import.js'
 import { open } from '@tauri-apps/api/dialog'
 import { handleError } from '@/store/state.js'
 
@@ -45,6 +45,30 @@ const profileOptions = ref([
   { name: 'Curseforge', path: '' },
   { name: 'PrismLauncher', path: '' },
 ])
+
+
+// Attempt to get import profiles on default paths
+const promises = profileOptions.value.map(async (option) => {
+  const path = await get_default_launcher_path(option.name).catch(handleError)
+  if (!path || path === '') return
+
+  // Try catch to allow failure and simply ignore default path attempt
+  try {
+    const instances = await get_importable_instances(
+      option.name,
+      path)
+  
+    if (!instances) return
+    profileOptions.value.find((profile) => profile.name === option.name).path = path
+    profiles.value.set(
+      option.name,
+      instances.map((name) => ({ name, selected: false }))
+    )
+  } catch (error) {
+    // Allow failure silently
+  }
+})
+Promise.all(promises)
 
 const selectLauncherPath = async () => {
   selectedProfileType.value.path = await open({ multiple: false, directory: true })

--- a/theseus_gui/src/helpers/events.js
+++ b/theseus_gui/src/helpers/events.js
@@ -62,7 +62,8 @@ export async function process_listener(callback) {
     ProfilePayload {
         uuid: unique identification of the process in the state (currently identified by path, but that will change)
         name: name of the profile
-        path: path to profile
+        profile_path: relative path to profile (used for path identification)
+        path: path to profile (used for opening the profile in the OS file explorer)
         event: event type ("Created", "Added", "Edited", "Removed")
     }
 */

--- a/theseus_gui/src/helpers/utils.js
+++ b/theseus_gui/src/helpers/utils.js
@@ -11,6 +11,11 @@ export async function isDev() {
   return await invoke('is_dev')
 }
 
+// One of 'Windows', 'Linux', 'MacOS'
+export async function getOS() {
+  return await invoke('plugin:utils|get_os')
+}
+
 export async function showInFolder(path) {
   return await invoke('plugin:utils|show_in_folder', { path })
 }

--- a/theseus_gui/src/pages/Settings.vue
+++ b/theseus_gui/src/pages/Settings.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, watch } from 'vue'
-import { Card, Slider, DropdownSelect, Checkbox, Toggle } from 'omorphia'
+import { Card, Slider, DropdownSelect, Toggle } from 'omorphia'
 import { handleError, useTheming } from '@/store/state'
 import { get, set } from '@/helpers/settings'
 import { get_max_memory } from '@/helpers/jre'
@@ -336,7 +336,16 @@ watch(
             Overwrites the option.txt file to start in full screen when launched.
           </span>
         </label>
-        <Checkbox id="fullscreen" v-model="settings.force_fullscreen" />
+        <Toggle
+          id="fullscreen"
+          :model-value="settings.force_fullscreen"
+          :checked="settings.force_fullscreen"
+          @update:model-value="
+            (e) => {
+              settings.force_fullscreen = e
+            }
+          "
+        />
       </div>
       <div class="adjacent-input">
         <label for="width">

--- a/theseus_gui/src/pages/instance/Index.vue
+++ b/theseus_gui/src/pages/instance/Index.vue
@@ -277,7 +277,7 @@ const handleOptionsClick = async (args) => {
 }
 
 const unlistenProfiles = await profile_listener(async (event) => {
-  if (event.path === route.params.id) {
+  if (event.profile_path_id === route.params.id) {
     if (event.event === 'removed') {
       await router.push({
         path: '/',

--- a/theseus_gui/src/pages/instance/Logs.vue
+++ b/theseus_gui/src/pages/instance/Logs.vue
@@ -15,7 +15,7 @@
           <CheckIcon v-else />
           {{ copied ? 'Copied' : 'Copy' }}
         </Button>
-        <Button color="primary" @click="share">
+        <Button color="primary" :disabled="!logs[selectedLogIndex]" @click="share">
           <ShareIcon />
           Share
         </Button>

--- a/theseus_gui/src/pages/instance/Mods.vue
+++ b/theseus_gui/src/pages/instance/Mods.vue
@@ -768,13 +768,12 @@ watch(selectAll, () => {
   }
 })
 
-
 const unlisten = await listen('tauri://file-drop', async (event) => {
-    for (const file of event.payload) {
-      if (file.endsWith('.mrpack')) continue
-      await add_project_from_path(props.instance.path, file, 'mod').catch(handleError)
-    }
-    initProjects(await get(props.instance.path).catch(handleError))
+  for (const file of event.payload) {
+    if (file.endsWith('.mrpack')) continue
+    await add_project_from_path(props.instance.path, file, 'mod').catch(handleError)
+  }
+  initProjects(await get(props.instance.path).catch(handleError))
 })
 onUnmounted(() => {
   unlisten()

--- a/theseus_gui/src/pages/instance/Mods.vue
+++ b/theseus_gui/src/pages/instance/Mods.vue
@@ -334,7 +334,7 @@ import {
   ShareModal,
   CodeIcon,
 } from 'omorphia'
-import { computed, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   add_project_from_path,
@@ -351,7 +351,6 @@ import { listen } from '@tauri-apps/api/event'
 import { convertFileSrc } from '@tauri-apps/api/tauri'
 import { showProfileInFolder } from '@/helpers/utils.js'
 import { MenuIcon, ToggleIcon, TextInputIcon, AddProjectImage } from '@/assets/icons'
-import { install_from_file } from '@/helpers/pack'
 
 const router = useRouter()
 
@@ -769,18 +768,16 @@ watch(selectAll, () => {
   }
 })
 
-listen('tauri://file-drop', async (event) => {
-  if (event.payload && event.payload.length > 0 && event.payload[0].endsWith('.mrpack')) {
-    await install_from_file(event.payload[0]).catch(handleError)
-  } else {
+
+const unlisten = await listen('tauri://file-drop', async (event) => {
     for (const file of event.payload) {
+      if (file.endsWith('.mrpack')) continue
       await add_project_from_path(props.instance.path, file, 'mod').catch(handleError)
     }
     initProjects(await get(props.instance.path).catch(handleError))
-  }
-  mixpanel.track('InstanceCreate', {
-    source: 'FileDrop',
-  })
+})
+onUnmounted(() => {
+  unlisten()
 })
 </script>
 

--- a/theseus_gui/src/pages/instance/Options.vue
+++ b/theseus_gui/src/pages/instance/Options.vue
@@ -639,8 +639,8 @@ const isChanged = computed(() => {
   return (
     loader.value != props.instance.metadata.loader ||
     gameVersion.value != props.instance.metadata.game_version ||
-    selectableLoaderVersions.value[loaderVersionIndex.value] !=
-      props.instance.metadata.loader_version
+    JSON.stringify(selectableLoaderVersions.value[loaderVersionIndex.value]) !=
+      JSON.stringify(props.instance.metadata.loader_version)
   )
 })
 

--- a/theseus_gui/src/pages/instance/Options.vue
+++ b/theseus_gui/src/pages/instance/Options.vue
@@ -42,7 +42,7 @@
         </button>
         <button
           class="btn btn-primary"
-          :disabled="!isValid || editing"
+          :disabled="!isValid || !isChanged || editing"
           @click="saveGvLoaderEdits()"
         >
           <SaveIcon />
@@ -71,7 +71,7 @@
           <UploadIcon />
           Select icon
         </button>
-        <button class="btn" @click="resetIcon">
+        <button  :disabled="!(!icon || (icon && icon.startsWith('http')) ? icon : convertFileSrc(icon))" class="btn" @click="resetIcon">
           <TrashIcon />
           Remove icon
         </button>
@@ -628,6 +628,15 @@ const isValid = computed(() => {
   return (
     selectableGameVersions.value.includes(gameVersion.value) &&
     (loaderVersionIndex.value >= 0 || loader.value === 'vanilla')
+  )
+})
+
+const isChanged = computed(() => {
+  return (
+    loader.value != props.instance.metadata.loader ||
+    gameVersion.value != props.instance.metadata.game_version ||
+    selectableLoaderVersions.value[loaderVersionIndex.value] !=
+      props.instance.metadata.loader_version
   )
 })
 

--- a/theseus_gui/src/pages/instance/Options.vue
+++ b/theseus_gui/src/pages/instance/Options.vue
@@ -97,8 +97,8 @@
       <button
         id="edit-versions"
         class="btn"
-        @click="$refs.changeVersionsModal.show()"
         :disabled="offline"
+        @click="$refs.changeVersionsModal.show()"
       >
         <EditIcon />
         Edit versions

--- a/theseus_gui/src/pages/instance/Options.vue
+++ b/theseus_gui/src/pages/instance/Options.vue
@@ -71,7 +71,11 @@
           <UploadIcon />
           Select icon
         </button>
-        <button  :disabled="!(!icon || (icon && icon.startsWith('http')) ? icon : convertFileSrc(icon))" class="btn" @click="resetIcon">
+        <button
+          :disabled="!(!icon || (icon && icon.startsWith('http')) ? icon : convertFileSrc(icon))"
+          class="btn"
+          @click="resetIcon"
+        >
           <TrashIcon />
           Remove icon
         </button>


### PR DESCRIPTION
Fixes #420 
Fixes #422 
Fixes #429 
Fixes #433 
Fixes #436  (improved bad-folder error msg and also now imports will auto-find the launcher's folder if it exists in the normal location)
Fixes #437
Fixes #438 (animation doesn't play on linux) 
Fixes #440 
Fixes #443  (note that it now plays after the modrinth loading circle/state initialization, as it does a check to the settings to see if onboarding is complete)
Fixes #448  (silence warning)
Fixes #452 
Fixes #453 
Fixes #456 
Fixes #458 

Fixes .mrpacks not having icons (now if no icon is provided on an import, icon.png will be used if it exists). See discussion on #455 and in discord