### PR TITLE
Fix z-index and add scrolling for AccountsCard

### DIFF
--- a/theseus_gui/src/components/ui/AccountsCard.vue
+++ b/theseus_gui/src/components/ui/AccountsCard.vue
@@ -222,7 +222,7 @@ onBeforeUnmount(() => {
   -webkit-user-select: none;
   max-height: 98vh;
   overflow-y: auto;
-  
+
   &::-webkit-scrollbar-track {
     border-top-right-radius: 1rem;
     border-bottom-right-radius: 1rem;

--- a/theseus_gui/src/components/ui/AccountsCard.vue
+++ b/theseus_gui/src/components/ui/AccountsCard.vue
@@ -212,7 +212,7 @@ onBeforeUnmount(() => {
   flex-direction: column;
   top: 0.5rem;
   left: 5.5rem;
-  z-index: 9;
+  z-index: 11;
   gap: 0.5rem;
   padding: 1rem;
   border: 1px solid var(--color-button-bg);
@@ -220,6 +220,18 @@ onBeforeUnmount(() => {
   user-select: none;
   -ms-user-select: none;
   -webkit-user-select: none;
+  max-height: 98vh;
+  overflow-y: auto;
+  
+  &::-webkit-scrollbar-track {
+    border-top-right-radius: 1rem;
+    border-bottom-right-radius: 1rem;
+  }
+
+  &::-webkit-scrollbar {
+    border-top-right-radius: 1rem;
+    border-bottom-right-radius: 1rem;
+  }
 
   &.hidden {
     display: none;


### PR DESCRIPTION
Bump account-card `z-index` to 11 (from 9) to fix issue with badges on the homepage being displayed above it. Also add a `max-height` and `overflow-y` to the account-card class, so that users with a large amount of accounts can view all accounts properly. 

![image](https://github.com/modrinth/theseus/assets/72168435/0a7b58d1-5fa5-4522-82d7-df4094da1611)

Related to this [message](https://discord.com/channels/734077874708938864/1120929730863050873/1140236231217778778) on the Modrinth Discord.