### PR TITLE
Fix being able to add mods to paired instances

### DIFF
--- a/theseus_gui/src/components/ui/ContextMenu.vue
+++ b/theseus_gui/src/components/ui/ContextMenu.vue
@@ -11,7 +11,11 @@
     >
       <div v-for="(option, index) in options" :key="index" @click.stop="optionClicked(option.name)">
         <hr v-if="option.type === 'divider'" class="divider" />
-        <div v-else class="item clickable" :class="[option.color ?? 'base']">
+        <div
+          v-else-if="!(isLinkedData(item) && option.name === `add_content`)"
+          class="item clickable"
+          :class="[option.color ?? 'base']"
+        >
           <slot :name="option.name" />
         </div>
       </div>
@@ -54,6 +58,16 @@ defineExpose({
     shown.value = true
   },
 })
+
+const isLinkedData = (item) => {
+  console.log(item)
+  if (item.instance != undefined && item.instance.metadata.linked_data) {
+    return true
+  } else if (item.metadata != undefined && item.metadata.linked_data) {
+    return true
+  }
+  return false
+}
 
 const hideContextMenu = () => {
   shown.value = false

--- a/theseus_gui/src/components/ui/ContextMenu.vue
+++ b/theseus_gui/src/components/ui/ContextMenu.vue
@@ -60,7 +60,6 @@ defineExpose({
 })
 
 const isLinkedData = (item) => {
-  console.log(item)
   if (item.instance != undefined && item.instance.metadata.linked_data) {
     return true
   } else if (item.metadata != undefined && item.metadata.linked_data) {

--- a/theseus_gui/src/components/ui/ModInstallModal.vue
+++ b/theseus_gui/src/components/ui/ModInstallModal.vue
@@ -245,13 +245,30 @@ const check_valid = computed(() => {
             />
             {{ profile.metadata.name }}
           </Button>
-          <Button :disabled="profile.installedMod || profile.installing" @click="install(profile)">
-            <DownloadIcon v-if="!profile.installedMod && !profile.installing" />
-            <CheckIcon v-else-if="profile.installedMod" />
-            {{
-              profile.installing ? 'Installing...' : profile.installedMod ? 'Installed' : 'Install'
-            }}
-          </Button>
+          <div
+            v-tooltip="
+              profile.metadata.linked_data && !profile.installedMod
+                ? 'Unpair an instance to add mods.'
+                : ''
+            "
+          >
+            <Button
+              :disabled="profile.installedMod || profile.installing || profile.metadata.linked_data"
+              @click="install(profile)"
+            >
+              <DownloadIcon v-if="!profile.installedMod && !profile.installing" />
+              <CheckIcon v-else-if="profile.installedMod" />
+              {{
+                profile.installing
+                  ? 'Installing...'
+                  : profile.installedMod
+                  ? 'Installed'
+                  : profile.metadata.linked_data
+                  ? 'Paired'
+                  : 'Install'
+              }}
+            </Button>
+          </div>
         </div>
       </div>
       <Card v-if="showCreation" class="creation-card">


### PR DESCRIPTION
Disabled all buttons that have actions on mods except share actions when the instance is still paired to a modpack. Every single disabled button includes a tooltip that has text similar to this: "Unpair this instance to update mods". Also added a message to the mod install modal to let the user know that they cannot add mods to a paired instance. 

Had to wrap all disabled elements in an extra div because the root element is disabled and from my testing disabled elements don't allow tooltips.

![image](https://github.com/modrinth/theseus/assets/72168435/f3da4129-0ebb-43b2-9a1e-acc54d9862b2)![image](https://github.com/modrinth/theseus/assets/72168435/7caa344c-2d35-4bc0-a545-c37af1dde225)

![image](https://github.com/modrinth/theseus/assets/72168435/7af3c210-e39c-41c7-88d4-561c8b2d257b)




Fixes #625 