### PR TITLE
Fixing bug report template - Wrong nesting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
       required: false
   - type: textarea
     attributes: System information
-      description: Add any information about what OS you are on (like Windows or Mac), and what version of the app you are using.
+      description: "Add any information about what OS you are on (like Windows or Mac), and what version of the app you are using."
   - type: textarea
     attributes:
       label: Additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,8 +26,9 @@ body:
     validations:
       required: false
   - type: textarea
-    attributes: System information
-      description: "Add any information about what OS you are on (like Windows or Mac), and what version of the app you are using."
+    attributes: 
+      label: System information
+      description: Add any information about what OS you are on (like Windows or Mac), and what version of the app you are using.
   - type: textarea
     attributes:
       label: Additional context


### PR DESCRIPTION
The label was added to the parent tag `attributes` instead of being added inside it to the `label` tag,

First commit was test to fix the issue while not seeing the real issue (reverted in second commit)