### PR TITLE
Allow mods to be added to unlocked instances.

### DIFF
--- a/theseus_gui/src/components/ui/ModInstallModal.vue
+++ b/theseus_gui/src/components/ui/ModInstallModal.vue
@@ -247,18 +247,14 @@ const check_valid = computed(() => {
           </Button>
           <div
             v-tooltip="
-              profile.metadata.linked_data &&
-              !profile.installedMod &&
-              profile.metadata.linked_data.locked
+              profile.metadata.linked_data?.locked && !profile.installedMod
                 ? 'Unpair or unlock an instance to add mods.'
                 : ''
             "
           >
             <Button
               :disabled="
-                profile.installedMod ||
-                profile.installing ||
-                (profile.metadata.linked_data && profile.metadata.linked_data.locked)
+                profile.installedMod || profile.installing || profile.metadata.linked_data?.locked
               "
               @click="install(profile)"
             >

--- a/theseus_gui/src/components/ui/ModInstallModal.vue
+++ b/theseus_gui/src/components/ui/ModInstallModal.vue
@@ -247,13 +247,19 @@ const check_valid = computed(() => {
           </Button>
           <div
             v-tooltip="
-              profile.metadata.linked_data && !profile.installedMod
-                ? 'Unpair an instance to add mods.'
+              profile.metadata.linked_data &&
+              !profile.installedMod &&
+              profile.metadata.linked_data.locked
+                ? 'Unpair or unlock an instance to add mods.'
                 : ''
             "
           >
             <Button
-              :disabled="profile.installedMod || profile.installing || profile.metadata.linked_data"
+              :disabled="
+                profile.installedMod ||
+                profile.installing ||
+                (profile.metadata.linked_data && profile.metadata.linked_data.locked)
+              "
               @click="install(profile)"
             >
               <DownloadIcon v-if="!profile.installedMod && !profile.installing" />
@@ -263,7 +269,7 @@ const check_valid = computed(() => {
                   ? 'Installing...'
                   : profile.installedMod
                   ? 'Installed'
-                  : profile.metadata.linked_data
+                  : profile.metadata.linked_data && profile.metadata.linked_data.locked
                   ? 'Paired'
                   : 'Install'
               }}


### PR DESCRIPTION
Change some lines in the mod install modal to allow adding mods to unlocked instances, also changed the disabled tooltip to mention unlocking an instance to add mods.

Fixes #746