### PR TITLE
Overflow and mrpack fixes, comfortable memory slider and more.

### DIFF
--- a/theseus_gui/src/components/ui/Instance.vue
+++ b/theseus_gui/src/components/ui/Instance.vue
@@ -187,7 +187,7 @@ onUnmounted(() => unlisten())
   <div class="instance">
     <Card class="instance-card-item button-base" @click="seeInstance" @mouseenter="checkProcess">
       <Avatar
-        size="sm"
+        size="lg"
         :src="
           props.instance.metadata
             ? !props.instance.metadata.icon ||

--- a/theseus_gui/src/components/ui/InstanceCreationModal.vue
+++ b/theseus_gui/src/components/ui/InstanceCreationModal.vue
@@ -20,7 +20,13 @@
       </div>
       <div class="input-row">
         <p class="input-label">Name</p>
-        <input v-model="profile_name" autocomplete="off" class="text-input" type="text" />
+        <input
+          v-model="profile_name"
+          autocomplete="off"
+          class="text-input"
+          type="text"
+          maxlength="100"
+        />
       </div>
       <div class="input-row">
         <p class="input-label">Loader</p>

--- a/theseus_gui/src/pages/Browse.vue
+++ b/theseus_gui/src/pages/Browse.vue
@@ -549,7 +549,11 @@ onUnmounted(() => unlistenOffline())
             size="sm"
           />
           <div class="small-instance_info">
-            <span class="title">{{ instanceContext.metadata.name }}</span>
+            <span class="title">{{
+              instanceContext.metadata.name.length > 20
+                ? instanceContext.metadata.name.substring(0, 20) + '...'
+                : instanceContext.metadata.name
+            }}</span>
             <span>
               {{
                 instanceContext.metadata.loader.charAt(0).toUpperCase() +

--- a/theseus_gui/src/pages/Settings.vue
+++ b/theseus_gui/src/pages/Settings.vue
@@ -385,7 +385,7 @@ async function refreshDir() {
           v-model="settings.memory.maximum"
           :min="8"
           :max="maxMemory"
-          :step="1"
+          :step="64"
           unit="mb"
         />
       </div>

--- a/theseus_gui/src/pages/instance/Index.vue
+++ b/theseus_gui/src/pages/instance/Index.vue
@@ -161,7 +161,13 @@ const breadcrumbs = useBreadcrumbs()
 
 const instance = ref(await get(route.params.id).catch(handleError))
 
-breadcrumbs.setName('Instance', instance.value.metadata.name)
+breadcrumbs.setName(
+  'Instance',
+  instance.value.metadata.name.length > 40
+    ? instance.value.metadata.name.substring(0, 40) + '...'
+    : instance.value.metadata.name
+)
+
 breadcrumbs.setContext({
   name: instance.value.metadata.name,
   link: route.path,
@@ -366,6 +372,8 @@ Button {
 .name {
   font-size: 1.25rem;
   color: var(--color-contrast);
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .metadata {

--- a/theseus_gui/src/pages/instance/Index.vue
+++ b/theseus_gui/src/pages/instance/Index.vue
@@ -209,7 +209,7 @@ const checkProcess = async () => {
 
 // Get information on associated modrinth versions, if any
 const modrinthVersions = ref([])
-if (!(await isOffline()) && instance.value.metadata.linked_data) {
+if (!(await isOffline()) && instance.value.metadata.linked_data?.project_id) {
   modrinthVersions.value = await useFetch(
     `https://api.modrinth.com/v2/project/${instance.value.metadata.linked_data.project_id}/version`,
     'project'

--- a/theseus_gui/src/pages/instance/Logs.vue
+++ b/theseus_gui/src/pages/instance/Logs.vue
@@ -526,6 +526,13 @@ onUnmounted(() => {
   flex-direction: row;
   overflow: auto;
   gap: 0.5rem;
+
+  &::-webkit-scrollbar-track {
+    border-radius: 10px;
+  }
+  &::-webkit-scrollbar {
+    border-radius: 10px;
+  }
 }
 
 :deep(.vue-recycle-scroller__item-wrapper) {

--- a/theseus_gui/src/pages/instance/Logs.vue
+++ b/theseus_gui/src/pages/instance/Logs.vue
@@ -524,6 +524,7 @@ onUnmounted(() => {
   display: flex;
   padding: 0.6rem;
   flex-direction: row;
+  overflow: auto;
   gap: 0.5rem;
 }
 

--- a/theseus_gui/src/pages/instance/Logs.vue
+++ b/theseus_gui/src/pages/instance/Logs.vue
@@ -527,16 +527,21 @@ onUnmounted(() => {
   overflow: auto;
   gap: 0.5rem;
 
-  &::-webkit-scrollbar-track {
-    border-radius: 10px;
-  }
-  &::-webkit-scrollbar {
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-thumb {
     border-radius: 10px;
   }
 }
 
 :deep(.vue-recycle-scroller__item-wrapper) {
   overflow: visible; /* Enables horizontal scrolling */
+}
+
+:deep(.vue-recycle-scroller) {
+  &::-webkit-scrollbar-corner {
+    background-color: var(--color-bg);
+    border-radius: 0 0 10px 0;
+  }
 }
 
 .scroller {

--- a/theseus_gui/src/pages/instance/Options.vue
+++ b/theseus_gui/src/pages/instance/Options.vue
@@ -362,7 +362,10 @@
         <span class="label__description">
           <strong>Version: </strong>
           {{
-            installedVersionData.name.charAt(0).toUpperCase() + installedVersionData.name.slice(1)
+            installedVersionData?.name != null
+              ? installedVersionData.name.charAt(0).toUpperCase() +
+                installedVersionData.name.slice(1)
+              : getLocalVersion(props.instance.path)
           }}
         </span>
       </label>
@@ -401,7 +404,7 @@
       </Button>
     </div>
 
-    <div class="adjacent-input">
+    <div v-if="props.instance.metadata.linked_data.project_id" class="adjacent-input">
       <label for="change-modpack-version">
         <span class="label__title">Change modpack version</span>
         <span class="label__description">
@@ -641,9 +644,10 @@ const unlinkModpack = ref(false)
 const inProgress = ref(false)
 const installing = computed(() => props.instance.install_stage !== 'installed')
 const installedVersion = computed(() => props.instance?.metadata?.linked_data?.version_id)
-const installedVersionData = computed(() =>
-  props.versions.find((version) => version.id === installedVersion.value)
-)
+const installedVersionData = computed(() => {
+  if (!installedVersion.value) return null
+  return props.versions.find((version) => version.id === installedVersion.value)
+})
 
 watch(
   [
@@ -670,6 +674,15 @@ watch(
   },
   { deep: true }
 )
+
+const getLocalVersion = (path) => {
+  const pathSlice = path.split(' ').slice(-1).toString()
+  // If the path ends in (1), (2), etc. it's a duplicate instance and no version can be obtained.
+  if (/^\(\d\)/.test(pathSlice)) {
+    return 'Unknown'
+  }
+  return pathSlice
+}
 
 const editProfileObject = computed(() => {
   const editProfile = {

--- a/theseus_gui/src/pages/instance/Options.vue
+++ b/theseus_gui/src/pages/instance/Options.vue
@@ -243,7 +243,7 @@
         :disabled="!overrideMemorySettings"
         :min="8"
         :max="maxMemory"
-        :step="1"
+        :step="64"
         unit="mb"
       />
     </div>

--- a/theseus_gui/src/pages/project/Index.vue
+++ b/theseus_gui/src/pages/project/Index.vue
@@ -14,7 +14,11 @@
             size="sm"
           />
           <div class="small-instance_info">
-            <span class="title">{{ instance.metadata.name }}</span>
+            <span class="title">{{
+              instance.metadata.name.length > 20
+                ? instance.metadata.name.substring(0, 20) + '...'
+                : instance.metadata.name
+            }}</span>
             <span>
               {{
                 instance.metadata.loader.charAt(0).toUpperCase() + instance.metadata.loader.slice(1)


### PR DESCRIPTION
1. Added a limit for the instance name in the breadcrumbs, so that a very long (~50char) instance name doesn't push aside the other elements, making exiting the application impossible. Fixed overflow in mod browse. Fixes #740 
3. Added a limit of 100 characters in the instance creation modal, there is no reason for an instance's name to be longer.
4. Fixed log viewing options overflowing with a small window, now they are scrollable.
5. Increased instance avatar size from `sm` to `lg` in the library so that the gray corners in icons are less visible.
6. Fixed and rounded the white corner in the log viewer.
7. Increase step to 64 for memory related inputs for a more consistent and comfortable experience.
8. Fix instances imported from an mrpack file throwing an error (making it impossible to unpair a locally imported mrpack) when viewing. Fixes #747 
10. Removed changing modpack versions on instances imported from a local mrpack.


![image](https://github.com/modrinth/theseus/assets/72168435/c7d812f5-a8a7-4747-9494-49ef5a8c6cc8)
![image](https://github.com/modrinth/theseus/assets/72168435/18b9687c-03e9-49ca-ab72-bdd43bc6b30f)
![image](https://github.com/modrinth/theseus/assets/72168435/cd552134-5d87-4286-a3f2-5ba8bc725ddc)
![image](https://github.com/modrinth/theseus/assets/72168435/c50bc7e5-7f80-49a5-95e7-f7d05d870e44)

