### PR TITLE
Use 'neoforge' instead of 'neo-forge' in mrpacks [MOD-539]

### DIFF
--- a/theseus/src/api/pack/install_from.rs
+++ b/theseus/src/api/pack/install_from.rs
@@ -66,12 +66,21 @@ pub enum EnvType {
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Hash, PartialEq, Eq, Debug)]
-#[serde(rename_all = "kebab-case")]
 pub enum PackDependency {
+    #[serde(rename = "forge")]
     Forge,
+
+    #[serde(rename = "neoforge")]
+    #[serde(alias = "neo-forge")]
     NeoForge,
+
+    #[serde(rename = "fabric-loader")]
     FabricLoader,
+
+    #[serde(rename = "quilt-loader")]
     QuiltLoader,
+
+    #[serde(rename = "minecraft")]
     Minecraft,
 }
 


### PR DESCRIPTION
Fixes #772. Stays backwards compatible in case any packs were produced locally with the old serialization.