### PR TITLE
Search pagination fix

### DIFF
--- a/theseus_gui/src/components/ui/AccountsCard.vue
+++ b/theseus_gui/src/components/ui/AccountsCard.vue
@@ -2,7 +2,7 @@
   <div
     v-if="mode !== 'isolated'"
     ref="button"
-    v-tooltip="'Minecraft accounts'"
+    v-tooltip.right="'Minecraft accounts'"
     class="button-base avatar-button"
     :class="{ expanded: mode === 'expanded' }"
     @click="showCard = !showCard"

--- a/theseus_gui/src/pages/instance/Mods.vue
+++ b/theseus_gui/src/pages/instance/Mods.vue
@@ -542,6 +542,8 @@ const ascending = ref(true)
 const sortColumn = ref('Name')
 const currentPage = ref(1)
 
+watch(searchFilter, () => currentPage.value = 1)
+
 const selected = computed(() =>
   Array.from(selectionMap.value)
     .filter((args) => {


### PR DESCRIPTION
The bug was caused by the page number staying the same even when there are fewer number of pages. I fixed this by setting the page to 1 when a new search is performed.

Fixes #798 