### PR TITLE
instance specific discord-rpc

### DIFF
--- a/theseus/src/launcher/mod.rs
+++ b/theseus/src/launcher/mod.rs
@@ -602,11 +602,16 @@ pub async fn launch_minecraft(
     }
 
     if !*state.offline.read().await {
-        // Add game played to discord rich presence
-        let _ = state
-            .discord_rpc
-            .set_activity(&format!("Playing {}", profile.metadata.name), true)
-            .await;
+        if profile.disable_discord_rpc {
+            // Remove discord rich presence
+            let _ = state.discord_rpc.clear_activity(true).await;
+        }else{
+            // Add game played to discord rich presence
+            let _ = state
+                .discord_rpc
+                .set_activity(&format!("Playing {}", profile.metadata.name), true)
+                .await;
+        }
     }
 
     // Create Minecraft child by inserting it into the state

--- a/theseus/src/state/profiles.rs
+++ b/theseus/src/state/profiles.rs
@@ -207,6 +207,8 @@ pub struct Profile {
     pub projects: HashMap<ProjectPathId, Project>,
     #[serde(default)]
     pub modrinth_update_version: Option<String>,
+    #[serde(default)]
+    pub disable_discord_rpc: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -342,6 +344,7 @@ impl Profile {
             fullscreen: None,
             hooks: None,
             modrinth_update_version: None,
+            disable_discord_rpc: false,
         })
     }
 

--- a/theseus_gui/src-tauri/src/api/profile.rs
+++ b/theseus_gui/src-tauri/src/api/profile.rs
@@ -292,6 +292,7 @@ pub struct EditProfile {
     pub resolution: Option<WindowSize>,
     pub hooks: Option<Hooks>,
     pub fullscreen: Option<bool>,
+    pub disable_discord_rpc: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -335,6 +336,7 @@ pub async fn profile_edit(
         prof.resolution = edit_profile.resolution;
         prof.fullscreen = edit_profile.fullscreen;
         prof.hooks = edit_profile.hooks.clone();
+        prof.disable_discord_rpc = edit_profile.disable_discord_rpc;
 
         prof.metadata.date_modified = chrono::Utc::now();
 

--- a/theseus_gui/src/pages/instance/Options.vue
+++ b/theseus_gui/src/pages/instance/Options.vue
@@ -196,6 +196,22 @@
         "
       />
     </div>
+    <div class="adjacent-input">
+      <label for="disable-discord-rpc">
+        <span class="label__title">Disable Discord RPC</span>
+        <span class="label__description">
+          Disables the Discord Rich Presence integration. 'Modrinth' will no longer show this
+          instance as running. Instance-specific Discord Rich Presence integrations, such as those
+          added by mods can take over.
+        </span>
+      </label>
+      <Toggle
+        id="disable-discord-rpc"
+        v-model="disableDiscordRPC"
+        :disabled="globalSettings.disable_discord_rpc"
+        :checked="disableDiscordRPC"
+      />
+    </div>
   </section>
   <Card>
     <div class="label">
@@ -519,6 +535,7 @@ import {
   DownloadIcon,
   ClipboardCopyIcon,
   Button,
+  Toggle,
 } from 'omorphia'
 import { SwapIcon } from '@/assets/icons'
 
@@ -574,6 +591,7 @@ const themeStore = useTheming()
 const title = ref(props.instance.metadata.name)
 const icon = ref(props.instance.metadata.icon)
 const groups = ref(props.instance.metadata.groups)
+const disableDiscordRPC = ref(props.instance.disable_discord_rpc)
 
 const modpackVersionModal = ref(null)
 
@@ -655,7 +673,7 @@ watch(
   [
     title,
     groups,
-    groups,
+    disableDiscordRPC,
     overrideJavaInstall,
     javaInstall,
     overrideJavaArgs,
@@ -694,6 +712,7 @@ const editProfileObject = computed(() => {
       loader_version: props.instance.metadata.loader_version,
       linked_data: props.instance.metadata.linked_data,
     },
+    disable_discord_rpc: disableDiscordRPC.value,
     java: {},
   }
 


### PR DESCRIPTION
this PR adds the option to disable the discord-rpc on a per-instance bases

so whenever the instance runs the rpc automatically gets disabled this is so things like `CraftPresence` can take over

![grafik](https://github.com/modrinth/theseus/assets/81473300/ad62e08c-706b-4bef-a7d3-b70cacbd8098)
