### PR TITLE
Project without space

### DIFF
--- a/theseus_gui/src/helpers/profile.js
+++ b/theseus_gui/src/helpers/profile.js
@@ -17,6 +17,8 @@ import { invoke } from '@tauri-apps/api/tauri'
 */
 
 export async function create(name, gameVersion, modloader, loaderVersion, icon, noWatch) {
+  //Trim string name to avoid "Unable to find directory"
+  name = name.trim();
   return await invoke('plugin:profile_create|profile_create', {
     name,
     gameVersion,


### PR DESCRIPTION
Fixed bug when creating instance starting or ending with spaces has errors

Based on issue #765 & #808 