### PR TITLE
Fix handling of paths longer than 260 chars on Windows during export

### DIFF
--- a/theseus/src/error.rs
+++ b/theseus/src/error.rs
@@ -34,6 +34,9 @@ pub enum ErrorKind {
     #[error("I/O error: {0}")]
     IOError(#[from] util::io::IOError),
 
+    #[error("I/O (std) error: {0}")]
+    StdIOError(#[from] std::io::Error),
+
     #[error("Error launching Minecraft: {0}")]
     LauncherError(String),
 

--- a/theseus/src/state/profiles.rs
+++ b/theseus/src/state/profiles.rs
@@ -142,10 +142,13 @@ pub struct ProjectPathId(pub PathBuf);
 impl ProjectPathId {
     // Create a new ProjectPathId from a full file path
     pub async fn from_fs_path(path: &PathBuf) -> crate::Result<Self> {
-        let profiles_dir: PathBuf = io::canonicalize(
+        // This is avoiding dunce::canonicalize deliberately. On Windows, paths will always be convert to UNC,
+        // but this is ok because we are stripping that with the prefix. Using std::fs avoids different behaviors with dunce that
+        // come with too-long paths
+        let profiles_dir: PathBuf = std::fs::canonicalize(
             State::get().await?.directories.profiles_dir().await,
         )?;
-        let path: PathBuf = io::canonicalize(path)?;
+        let path: PathBuf = std::fs::canonicalize(path)?;
         let path = path
             .strip_prefix(profiles_dir)
             .ok()


### PR DESCRIPTION
This addresses an issue brought to our attention by the modpack "Mimi Adventure", with the following repro steps, using version 0.6.0 of the app on Windows:
1. Create a profile using the modpack "Mimi Adventure" (https://modrinth.com/modpack/mimi-adventure)
2. Unpair the profile
3. Launch minecraft
4. Export the modpack with the "pfm" folder included as an override.
This produces the following error:
```
Filesystem error: Path "\\\\?\\C:\\Users\\USER\\AppData\\Roaming\\com.modrinth.theseus\\profiles\\Mimi\\pfm\\cache\\resources\\assets\\pfm\\models\\block\\chair_classic\\stripped_luphie_flowering_pink_luphieclutteredmod_chair_classic\\stripped_luphie_flowering_pink_luphieclutteredmod_chair_classic_tucked.json" does not correspond to a profile
```

This error occurs because the path length is over 260 characters ([Windows docs](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation)), which caused `dunce::canonicalize` ([lib.rs line 187](https://gitlab.com/kornelski/dunce/-/blob/master/src/lib.rs?ref_type=heads#L187)) to default to `std::fs::canonicalize`, which canonicalizes to a [UNC path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths). This path begins with "\\\\?\\", so when we try to strip the profile prefix (which isn't UNC) from the file's path, it fails.

My (somewhat clunky) solution is to use `std::fs::canonicalize` for both the profile path and the one we're canonicalizing, which should behave consistently regardless of length. The UNC path weirdness shouldn't matter to us here as we're only doing this if we can subtract the canonicalized profile path from the input path, canceling out the UNC prefix.