### PR TITLE
change instance fullscreen-checkbox to toggle

### DIFF
--- a/theseus_gui/src/pages/instance/Options.vue
+++ b/theseus_gui/src/pages/instance/Options.vue
@@ -264,7 +264,17 @@
           Make the game start in full screen when launched (using options.txt).
         </span>
       </label>
-      <Checkbox id="fullscreen" v-model="fullscreenSetting" :disabled="!overrideWindowSettings" />
+      <Toggle
+        id="fullscreen"
+        :model-value="fullscreenSetting"
+        :checked="fullscreenSetting"
+        :disabled="!overrideWindowSettings"
+        @update:model-value="
+          (e) => {
+            fullscreenSetting = e
+          }
+        "
+      />
     </div>
     <div class="adjacent-input">
       <label for="width">
@@ -519,6 +529,7 @@ import {
   DownloadIcon,
   ClipboardCopyIcon,
   Button,
+  Toggle,
 } from 'omorphia'
 import { SwapIcon } from '@/assets/icons'
 


### PR DESCRIPTION
This PR changes the fullscreen option in instance to be a toggle instead of a checkbox so it is more consistent

now:
![grafik](https://github.com/modrinth/theseus/assets/81473300/fa421321-2c93-45f4-a207-f210b86d9f10)

PR:
![grafik](https://github.com/modrinth/theseus/assets/81473300/e69d1979-ce95-4add-a512-befbfb94764e)

