### PR TITLE
Prevent user from opening the app as Administrator on Windows

### DIFF
--- a/theseus/src/api/hydra/stages/poll_response.rs
+++ b/theseus/src/api/hydra/stages/poll_response.rs
@@ -87,8 +87,10 @@ pub async fn poll_response(device_code: String) -> crate::Result<OauthSuccess> {
                     }
                     _ => {
                         return Err(crate::ErrorKind::HydraError(format!(
-                            "Unknown error: {}",
-                            failure.error
+                            "Unknown error: {}\n{}\n{:#?}",
+                            failure.error,
+                            failure.error_description,
+                            failure.error_codes
                         ))
                         .as_error());
                     }


### PR DESCRIPTION
Should help quell issues where the user has opened the app as administrator and created permission issues.