### PR TITLE
fix rendering/calculation of maxProjectsPerRow in homepage

### DIFF
--- a/theseus_gui/src/components/RowDisplay.vue
+++ b/theseus_gui/src/components/RowDisplay.vue
@@ -203,8 +203,8 @@ const handleOptionsClick = async (args) => {
   }
 }
 
-const maxInstancesPerRow = ref(0)
-const maxProjectsPerRow = ref(0)
+const maxInstancesPerRow = ref(1)
+const maxProjectsPerRow = ref(1)
 
 const calculateCardsPerRow = () => {
   // Calculate how many cards fit in one row


### PR DESCRIPTION
This PR fixes a weird behavior that sometimes causes too many projects to be displayed

![grafik](https://github.com/modrinth/theseus/assets/81473300/b96e529a-66c9-455d-9ba8-8fd2823eb90c)

reason why this happened:
the `onMount` hock renders the page and then gets called which in most cases results in the container element in which the projects are rendered to be the correct width without any projects being inside them.
There is just the edge case where the height of the projects adds a scrollbar on the side which changes the width of the container without triggering a resize.

this PR fixes this by always rendering one element which forces a scrollbar to be rendered before `onMount`
