### PR TITLE
Add missing noblur value to modals.

### DIFF
--- a/theseus_gui/src/components/ui/AccountsCard.vue
+++ b/theseus_gui/src/components/ui/AccountsCard.vue
@@ -62,7 +62,7 @@
       </Button>
     </Card>
   </transition>
-  <Modal ref="loginModal" class="modal" header="Signing in">
+  <Modal ref="loginModal" class="modal" header="Signing in" :noblur="!themeStore.advancedRendering">
     <div class="modal-body">
       <QrcodeVue :value="loginUrl" class="qr-code" margin="3" size="160" />
       <div class="modal-text">
@@ -120,6 +120,7 @@ import {
 } from '@/helpers/auth'
 import { get, set } from '@/helpers/settings'
 import { handleError } from '@/store/state.js'
+import { useTheming } from '@/store/theme.js'
 import { mixpanel_track } from '@/helpers/mixpanel'
 import QrcodeVue from 'qrcode.vue'
 import { process_listener } from '@/helpers/events'
@@ -136,6 +137,7 @@ const emit = defineEmits(['change'])
 
 const loginCode = ref(null)
 
+const themeStore = useTheming()
 const settings = ref({})
 const accounts = ref([])
 const loginUrl = ref('')

--- a/theseus_gui/src/components/ui/tutorial/LoginCard.vue
+++ b/theseus_gui/src/components/ui/tutorial/LoginCard.vue
@@ -2,11 +2,13 @@
 import { Button, LogInIcon, Modal, ClipboardCopyIcon, GlobeIcon, Card } from 'omorphia'
 import { authenticate_await_completion, authenticate_begin_flow } from '@/helpers/auth.js'
 import { handleError } from '@/store/notifications.js'
+import { useTheming } from '@/store/theme.js'
 import mixpanel from 'mixpanel-browser'
 import { get, set } from '@/helpers/settings.js'
 import { ref } from 'vue'
 import QrcodeVue from 'qrcode.vue'
 
+const themeStore = useTheming()
 const loginUrl = ref(null)
 const loginModal = ref()
 const loginCode = ref(null)
@@ -94,7 +96,7 @@ const clipboardWrite = async (a) => {
       </div>
     </Card>
   </div>
-  <Modal ref="loginModal" header="Signing in">
+  <Modal ref="loginModal" header="Signing in" :noblur="!themeStore.advancedRendering">
     <div class="modal-body">
       <QrcodeVue :value="loginUrl" class="qr-code" margin="3" size="160" />
       <div class="modal-text">


### PR DESCRIPTION
This PR fixes the missing `:noblur` from various login modals, making it so that users with no advanced rendering still get the blurry background.

Closes #713