### PR TITLE
fix custom profile import for CF

### DIFF
--- a/theseus/src/api/pack/import/curseforge.rs
+++ b/theseus/src/api/pack/import/curseforge.rs
@@ -106,12 +106,12 @@ pub async fn import_curseforge(
         let mut mod_loader = None;
         let mut loader_version = None;
 
-        match instance_mod_loader.name.split_once('-') {
-            Some(("forge", version)) => {
+        match instance_mod_loader.name.split('-').collect::<Vec<&str>>()[..] {
+            ["forge", version] => {
                 mod_loader = Some(ModLoader::Forge);
                 loader_version = Some(version.to_string());
             }
-            Some(("fabric", version)) => {
+            ["fabric", version, _game_version] => {
                 mod_loader = Some(ModLoader::Fabric);
                 loader_version = Some(version.to_string());
             }


### PR DESCRIPTION
currently importing a CF profile uses the manifest.json file to get the modloader. but this file does not exist for custom profiles (but only for premade modpacks).

getting the required info from minecraftinstance.json instead makes it possible to also import custom profiles from CF.
fixes #913 and #874

ill mark it as a draft for now because i still want to do some testing to make sure that minecraftinstance.json is reliable for all modloaders