### PR TITLE
Add text wrapping to project version names.

### DIFF
--- a/theseus_gui/src/pages/project/Versions.vue
+++ b/theseus_gui/src/pages/project/Versions.vue
@@ -283,6 +283,7 @@ watch([filterVersions, filterLoader, filterGameVersions], () => {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  text-wrap: wrap;
 
   .version-badge {
     display: flex;


### PR DESCRIPTION
Wrap the text inside project names to reflect the behavior on the website.


![image](https://github.com/modrinth/theseus/assets/72168435/778002ed-c985-45a3-be34-e981c6248b49)


 Closes #908