### PR TITLE
Remove lwjgl debugging argument.

### DIFF
--- a/theseus/src/launcher/args.rs
+++ b/theseus/src/launcher/args.rs
@@ -148,7 +148,6 @@ pub fn get_jvm_arguments(
             parsed_arguments.push(arg);
         }
     }
-    parsed_arguments.push("-Dorg.lwjgl.util.Debug=true".to_string());
 
     Ok(parsed_arguments)
 }


### PR DESCRIPTION
Removes the *seemingly* unnecessary lwjgl debugging argument added in https://github.com/modrinth/theseus/pull/98/commits/c6ff655422ceadce11893c09685cb10f70effb10.

Resolves https://github.com/modrinth/theseus/issues/947.