### PR TITLE
adds credentials refresh save

### DIFF
--- a/theseus/src/state/mr_auth.rs
+++ b/theseus/src/state/mr_auth.rs
@@ -351,6 +351,7 @@ pub async fn refresh_credentials(
         }
     }
 
+    credentials_store.save().await?;
     Ok(())
 }
 


### PR DESCRIPTION
Refresh is not saving credentials to file- resulting in auth.json file no longer matching session stored in db (as refresh call to the labrinth API modifies the token)

This error doesn't get printed to the console because it doesnt tell you if the refresh failed unless the refresh failed AND your current token's locally cached expiry date hasnt expired yet. So on the second or third boot-up, you are out of sync and theres no message printed until the token expires naturally