### PR TITLE
Use Tokio directly instead of Tauri in io.rs

### DIFF
--- a/theseus/src/util/io.rs
+++ b/theseus/src/util/io.rs
@@ -4,7 +4,7 @@
 use std::{path::Path, io::Write};
 
 use tempfile::NamedTempFile;
-use tauri::async_runtime::spawn_blocking;
+use tokio::task::spawn_blocking;
 
 #[derive(Debug, thiserror::Error)]
 pub enum IOError {


### PR DESCRIPTION
Fixes #1050 
As far as I can tell, the original Tauri call simply wraps the Tokio call. By using Tokio directly, we remove the `theseus` dependency upon Tauri.