### PR TITLE
Prompt users to provide debug info to support

### DIFF
--- a/theseus_gui/src/components/ui/ErrorModal.vue
+++ b/theseus_gui/src/components/ui/ErrorModal.vue
@@ -130,10 +130,10 @@ async function loginMinecraft() {
             If nothing is working and you need help, visit
             <a :href="supportLink">our support page</a>
             and start a chat using the widget in the bottom right and we will be more than happy to
-            assist!
+            assist! Make sure to provide the following debug information to the agent:
           </p>
           <details>
-            <summary>Debug info</summary>
+            <summary>Debug information</summary>
             {{ error.message ?? error }}
           </details>
         </template>


### PR DESCRIPTION
Many people contacting support forget to provide the debug information,
which significantly delays the resolution time because we're forced to
ask for this information anyway, as without it we cannot tell with
certainty the issue the person is facing.

Ideally in the future it would probably make sense to give a link to the
article describing the common issues for self-help, but there's no such
article yet. Perseus however is able to give suggestion for a few issues
given that it has the debug information.
