### PR TITLE
docs: remove mentions of theseus-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # theseus
-A game launcher which can be used as a CLI, GUI, and a library for creating and playing modrinth projects
+A game launcher which can be used as a GUI and a library for creating and playing modrinth projects
 
-Theseus aims to provide three components:
+Theseus aims to provide two components:
 - A library (theseus)
-- A CLI (theseus-cli)
 - A GUI (theseus-gui)
 
 Feel free to contribute!


### PR DESCRIPTION
As far as I understand from the discord, it is not planned. The code was silently removed in https://github.com/modrinth/theseus/commit/28779196393b59f06bcecbf88c77e49dc297989f. No need to say it can be used as a CLI then