### PR TITLE
Changed app category to “Game” to enable GameMode on macOS Sonoma 14+

### DIFF
--- a/theseus_gui/src-tauri/tauri.conf.json
+++ b/theseus_gui/src-tauri/tauri.conf.json
@@ -49,7 +49,7 @@
     "macOSPrivateApi": true,
     "bundle": {
       "active": true,
-      "category": "Entertainment",
+      "category": "Game",
       "copyright": "",
       "deb": {
         "depends": []


### PR DESCRIPTION
Issue #1175 
Some references from Apple's Website:
https://support.apple.com/en-en/105118
https://forums.developer.apple.com/forums/thread/739387